### PR TITLE
Update CI workflow trigger branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 env:


### PR DESCRIPTION
When we moved repository to Codex Org we also renamed `main` branch to the `master` one and this is why [CI workflow](https://github.com/codex-storage/nim-codex/blob/master/.github/workflows/ci.yml) stopped to run on push to the default branch.

We should make that working again.