### PR TITLE
Building Codex on FreeBSD

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -118,6 +118,51 @@ File: `C:/Users/<username>/AppData/Roaming/Code/User/settings.json`
 
 It is possible that nim-codex can be built and run on other platforms supported by the [Nim](https://nim-lang.org/) language: BSD family, older versions of Windows, etc. There has not been sufficient experimentation with nim-codex on such platforms, so instructions are not provided. Community contributions to these docs and our build system are welcome!
 
+
+#### FreeBSD
+
+1.  Ensure that the following system packages are installed:
+
+```shell
+pkg install bash git gmake gcc cmake rust 
+```
+
+2.  Run the normal build
+
+```shell
+gmake update
+gmake 
+```
+
+3.  The build will fail in compiling the wasmer-vm-2.3.0 crate with messages looking something like:
+
+```
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error> error: Unsupported platform [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error>    --> /home/evenson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmer-vm-2.3.0/src/trap/traphandlers.rs:305:21 [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error>     | [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error> 305 |                     compile_error!("Unsupported platform"); [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error>     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error>  [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error> error: could not compile `wasmer-vm` (lib) due to 1 previous error [User]
+/home/evenson/work/nim-codex/vendor/nim-circom-compat/circomcompat.nim(20, 9) Warning: rust error> warning: build failed, waiting for other jobs to finish... [User]
+``` 
+
+After the build fails, patch the Rust target under <file:.cargo/> with
+
+```shell
+patch -p1 < $NIM_CODEX_ROOT/docs/notes/wasmer-vm-2.3.0-freebsd-amd64.patch 
+```
+
+where NIM_CODEX_ROOT is set to the local location of the nim-codex repository.
+
+4.  Restart the build with
+
+```shell
+gmake 
+```
+
+Voila!  A Codex binary for FreeBSD!
+
 ## Repository
 
 In Bash run

--- a/config.nims
+++ b/config.nims
@@ -43,6 +43,17 @@ when defined(windows):
   # because these require direct manipulations of the stdout File object.
   switch("define", "chronicles_colors=off")
 
+# Fix problems linking <file:vendor/nim-circom-compat/> under FreeBSD
+#
+# Symptom:  codex executable fails to start due to undefined symbol `kinfo_getvmmap`
+#
+# Under FreeBSD the `kinfo_*` symbols are found in /usr/lib/libutil.a,
+# so this is presumably a problem with the circom-compat-ffi Rust
+# crate, and fixing things there would be a preferred solution, but
+# adding this change allows codex to run without updating Rust dependencies.
+when defined(freebsd):
+  switch("passL", "-lutil")
+
 # This helps especially for 32-bit x86, which sans SSE2 and newer instructions
 # requires quite roundabout code generation for cryptography, and other 64-bit
 # and larger arithmetic use cases, along with register starvation issues. When

--- a/docs/notes/wasmer-vm-2.3.0-freebsd-amd64.patch
+++ b/docs/notes/wasmer-vm-2.3.0-freebsd-amd64.patch
@@ -1,0 +1,12 @@
+--- a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmer-vm-2.3.0/src/trap/traphandlers.rs.orig	1973-11-29 21:33:09.000000000 +0000
++++ b/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmer-vm-2.3.0/src/trap/traphandlers.rs	2024-09-24 06:35:50.966457000 +0000
+@@ -274,6 +274,9 @@
+                 } else if #[cfg(all(target_os = "freebsd", target_arch = "x86"))] {
+                     pc = context.uc_mcontext.mc_rip as usize;
+                     sp = context.uc_mcontext.mc_rsp as usize;
++                } else if #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))] {
++                    pc = context.uc_mcontext.mc_rip as usize;
++                    sp = context.uc_mcontext.mc_rsp as usize;
+                 } else if #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))] {
+                     pc = (*context.uc_mcontext).__ss.__rip as usize;
+                     sp = (*context.uc_mcontext).__ss.__rsp as usize;


### PR DESCRIPTION
A pull request to encapsulate what I learned building Codex for freebsd-14.1 (amd64).  

I wouldn't recommend considering merging this request as-is, as A) this is my first experience at patching Nim/Nimbus codebases, and B) the actual changes have more to do with patching codex dependencies than modifying Codex itself.  

This pull request contains:

1.  Documentation of necessary additional FreeBSD system packages in BUILDING.md
2.  Modification to linking to overcome what I think is a problem in the `circom-compat-ffi` Rust crate in failing to include `/usr/lib/libutil.a` for its usage of `kinfo_*` interfaces
3.  A patch to the Rust wasmer-vm-2.3.0 dependency for amd64 architecture (an obvious mistake in the Rust source that is fixed in subsequent releases.

I would be happy for feedback on how to fix the problems in a smoother manner.