### PR TITLE
tests: measure test time

### DIFF
--- a/tests/asynctest.nim
+++ b/tests/asynctest.nim
@@ -1,3 +1,22 @@
 import pkg/asynctest/chronos/unittest
+import times, strutils
+
+type
+  TimedOutputFormatter* = ref object of ConsoleOutputFormatter
+    testStartTime: float
+
+method testStarted*(formatter: TimedOutputFormatter, testName: string) {.gcsafe.} =
+  formatter.testStartTime = epochTime()
+
+method testEnded*(formatter: TimedOutputFormatter, testResult: TestResult) =
+  let time = epochTime() - formatter.testStartTime
+  let timeStr = time.formatFloat(ffDecimal, precision = 8)
+  # There doesn't seem to be an easy way to override the echo in the base class
+  # without changing std/unittest, or copying most of the code here.
+  # We use a second line as a workaround.
+  procCall formatter.ConsoleOutputFormatter.testEnded(testResult)
+  echo "      time = ", timeStr, " sec"
+
+addOutputFormatter(TimedOutputFormatter())
 
 export unittest


### PR DESCRIPTION
Add time measurement to tests.

In this version we lose the color output. Unfortunately it can't be easily enabled because of private variables in the standard library.
We can work around this by copying most of the code from `std/unittest`, if desired. Ugly solution, but works.
