### PR TITLE
chore: sources ./env.sh and symlink local nimble

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,48 @@
+
+## Intro
+
+`codex.zshrc` will source the NBS environment setup script (`./env.sh`)
+automatically on startup into the integrated terminal environment so
+VSCode (or Codium) does not need to launched with `./env.sh codium .`.
+
+Additionally, to benefit from nimble updates, `nimble` will be symlinked from the user's home nimble
+installation folder (`~/.nimble/bin/nimble`). Nimble at this location should be at a version
+compatible with `nimlangserver` (`>= 0.16.1` ). Nimble can be updated with `nimble install
+nimble`.
+
+As of 1.8.0, `nimlangserver` is known to have bugs, so it's best to build it
+from master, by clong [the repo](https://github.com/nim-lang/langserver), then
+running `nimble install`.
+
+## Installation
+
+To ensure this script runs at startup and to properly setup VSCode's integrated
+terminal, you'll need to update your workspace settings to look like this:
+
+```json
+"terminal.integrated.profiles.osx": {
+  "zsh": {
+    "path": "/bin/zsh",
+    "args": [
+      "-l",
+      "-c",
+      "source ${workspaceFolder}/.vscode/codex.zshrc && zsh -i"
+    ]
+  },
+},
+"terminal.integrated.defaultProfile.osx": "zsh"
+```
+
+## Output on startup
+
+Once installed, on terminal startup, `codex.zshrc` will be sourced, and it will output all the
+relevant versions of libraries in the environment, eg:
+```shell
+Sourced NBS environment (/Users/egonat/repos/codex-storage/nim-codex/env.sh)
+
+nim:            2.0.14
+nimble:         0.16.4 (~/.nimble/bin/nimble)
+nimsuggest:     1.6.21
+nimlangserver:  1.8.1
+vscode-nim:     1.4.1
+```

--- a/.vscode/codex.zshrc
+++ b/.vscode/codex.zshrc
@@ -1,0 +1,27 @@
+SCRIPT_DIR=$(dirname $(readlink -f ${(%):-%N}))
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.."; pwd)
+
+source "$PROJECT_ROOT/env.sh"
+echo Sourced NBS environment \($PROJECT_ROOT/env.sh\)
+
+# Create symbolic link only if it doesn't exist
+REAL_NIMBLE_DIR=$PROJECT_ROOT/vendor/nimbus-build-system/vendor/Nim/bin
+if [ ! -L "$REAL_NIMBLE_DIR/nimble" ]; then
+    ln -s -F ~/.nimble/bin/nimble "$REAL_NIMBLE_DIR/nimble"
+fi
+echo ""
+echo "nim:           " $(nim --version | head -n1  | sed 's/Nim Compiler Version \([0-9.]*\).*/\1/')
+echo "nimble:        " $($REAL_NIMBLE_DIR/nimble --version | grep "nimble v" | sed 's/nimble v\([0-9.]*\).*/\1/')  \(~/.nimble/bin/nimble\)
+echo "nimsuggest:    " $(nimsuggest --version | head -n1 | sed 's/Nim Compiler Version \([0-9.]*\).*/\1/')
+if command -v nimlangserver >/dev/null 2>&1; then
+  echo "nimlangserver: " $(nimlangserver --version)
+fi
+if command -v codium >/dev/null 2>&1; then
+   VSCODE_CMD="codium"
+elif command -v code >/dev/null 2>&1; then
+   VSCODE_CMD="code"
+else
+   echo "Neither VSCode nor VSCodium found"
+   exit 1
+fi
+echo "vscode-nim:    " $($VSCODE_CMD --list-extensions --show-versions | grep "^nimlang.nimlang@" | cut -d'@' -f2)


### PR DESCRIPTION
This accomplishes two things:
1. No need to launch VSCode with `./env.sh code .`
2. Allows for a working `vscode-nim` (extension) and nimlangserver due to the correct nimble version (symlinked from ~/.nimble/bin/nimble to `nim-codex/vendor/nimbus-build-system/vendor/Nim/bin

My guess is that this is super hacky and probably not the best way to do it, but it works for me until NBS updates nimble.