### PR TITLE
feat: Multi threading support for circom prover

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -293,8 +293,9 @@ proc new*(
     store = NetworkStore.new(engine, repoStore)
     prover =
       if config.prover:
-        let backend =
-          config.initializeBackend().expect("Unable to create prover backend.")
+        let backend = config.initializeBackend(taskpool = taskpool).expect(
+            "Unable to create prover backend."
+          )
         some Prover.new(store, backend, config.numProofSamples)
       else:
         none Prover

--- a/codex/slots/proofs/backends/circomcompat.nim
+++ b/codex/slots/proofs/backends/circomcompat.nim
@@ -216,7 +216,7 @@ proc asyncProve*[H](
   let threadFut = threadPtr.wait()
 
   if joinErr =? catch(await threadFut.join()).errorOption:
-    if err=? catch(await noCancel threadFut).errorOption:
+    if err =? catch(await noCancel threadFut).errorOption:
       return failure(err)
     if joinErr of CancelledError:
       raise joinErr
@@ -249,11 +249,11 @@ proc circomVerifyTask(task: ptr VerifyTask) {.gcsafe.} =
 
   let res = verify_circuit(task[].proof, task[].inputs, task[].vkp)
   if res == ERR_OK:
-    task[].success[]=true
+    task[].success[] = true
   elif res == ERR_FAILED_TO_VERIFY_PROOF:
-    task[].success[]=false
+    task[].success[] = false
   else:
-    task[].success[]=false
+    task[].success[] = false
     error "Failed to verify proof", errorCode = res
 
 proc asyncVerify*[H](
@@ -287,14 +287,14 @@ proc asyncVerify*[H](
   self.taskpool.spawn circomVerifyTask(taskPtr)
 
   let threadFut = threadPtr.wait()
-  
+
   if joinErr =? catch(await threadFut.join()).errorOption:
-  if err=? catch(await noCancel threadFut).errorOption:
-    return failure(err)
-  if joinErr of CancelledError:
-    raise joinErr
-  else:
-    return failure(joinErr)
+    if err =? catch(await noCancel threadFut).errorOption:
+      return failure(err)
+    if joinErr of CancelledError:
+      raise joinErr
+    else:
+      return failure(joinErr)
 
   success()
 

--- a/codex/slots/proofs/backends/converters.nim
+++ b/codex/slots/proofs/backends/converters.nim
@@ -25,8 +25,6 @@ type
   CircomInputs* = Inputs
   VerifyResult* = Atomic[bool]
 
-export VerifyResult
-
 proc toCircomInputs*(inputs: ProofInputs[Poseidon2Hash]): CircomInputs =
   var
     slotIndex = inputs.slotIndex.toF.toBytes.toArray32

--- a/codex/slots/proofs/backends/converters.nim
+++ b/codex/slots/proofs/backends/converters.nim
@@ -23,14 +23,14 @@ type
   CircomProof* = Proof
   CircomKey* = VerifyingKey
   CircomInputs* = Inputs
-  VerifyResult* = ptr Atomic[bool]
+  VerifyResult* = ptr bool
   ProofPtr* = ptr Proof
 
 proc new*(_: type ProofPtr): ProofPtr =
   cast[ptr Proof](allocShared0(sizeof(Proof)))
 
 proc new*(_: type VerifyResult): VerifyResult =
-  cast[ptr Atomic[bool]](allocShared0(sizeof(Atomic[bool])))
+  cast[ptr bool](allocShared0(sizeof(bool)))
 
 proc toCircomInputs*(inputs: ProofInputs[Poseidon2Hash]): CircomInputs =
   var

--- a/codex/slots/proofs/backends/converters.nim
+++ b/codex/slots/proofs/backends/converters.nim
@@ -23,7 +23,16 @@ type
   CircomProof* = Proof
   CircomKey* = VerifyingKey
   CircomInputs* = Inputs
-  VerifyResult* = Atomic[bool]
+  VerifyResult* = ptr Atomic[bool]
+  ProofPtr* = ptr Proof
+
+export ProofPtr
+
+proc new*(_: type ProofPtr): ProofPtr =
+  cast[ptr Proof](allocShared0(sizeof(Proof)))
+
+proc new*(_: type VerifyResult): VerifyResult =
+  cast[ptr Atomic[bool]](allocShared0(sizeof(Atomic[bool])))
 
 proc toCircomInputs*(inputs: ProofInputs[Poseidon2Hash]): CircomInputs =
   var
@@ -55,17 +64,11 @@ func toG2*(g: CircomG2): G2Point =
 func toGroth16Proof*(proof: CircomProof): Groth16Proof =
   Groth16Proof(a: proof.a.toG1, b: proof.b.toG2, c: proof.c.toG1)
 
-proc newProof*(): ptr Proof =
-  result = cast[ptr Proof](allocShared0(sizeof(Proof)))
-
-proc newVerifyResult*(): ptr VerifyResult =
-  result = cast[ptr VerifyResult](allocShared0(sizeof(VerifyResult)))
-
-proc destroyVerifyResult*(result: ptr VerifyResult) =
+proc destroyVerifyResult*(result: VerifyResult) =
   if result != nil:
     deallocShared(result)
 
-proc destroyProof*(proof: ptr Proof) =
+proc destroyProof*(proof: ProofPtr) =
   if proof != nil:
     deallocShared(proof)
 

--- a/codex/slots/proofs/backends/converters.nim
+++ b/codex/slots/proofs/backends/converters.nim
@@ -26,8 +26,6 @@ type
   VerifyResult* = ptr Atomic[bool]
   ProofPtr* = ptr Proof
 
-export ProofPtr
-
 proc new*(_: type ProofPtr): ProofPtr =
   cast[ptr Proof](allocShared0(sizeof(Proof)))
 

--- a/codex/slots/proofs/backends/converters.nim
+++ b/codex/slots/proofs/backends/converters.nim
@@ -10,6 +10,7 @@
 {.push raises: [].}
 
 import pkg/circomcompat
+import std/atomics
 
 import ../../../contracts
 import ../../types
@@ -22,6 +23,9 @@ type
   CircomProof* = Proof
   CircomKey* = VerifyingKey
   CircomInputs* = Inputs
+  VerifyResult* = Atomic[bool]
+
+export VerifyResult
 
 proc toCircomInputs*(inputs: ProofInputs[Poseidon2Hash]): CircomInputs =
   var
@@ -52,3 +56,32 @@ func toG2*(g: CircomG2): G2Point =
 
 func toGroth16Proof*(proof: CircomProof): Groth16Proof =
   Groth16Proof(a: proof.a.toG1, b: proof.b.toG2, c: proof.c.toG1)
+
+proc newProof*(): ptr Proof =
+  result = cast[ptr Proof](allocShared0(sizeof(Proof)))
+
+proc newVerifyResult*(): ptr VerifyResult =
+  result = cast[ptr VerifyResult](allocShared0(sizeof(VerifyResult)))
+
+proc destroyVerifyResult*(result: ptr VerifyResult) =
+  if result != nil:
+    deallocShared(result)
+
+proc destroyProof*(proof: ptr Proof) =
+  if proof != nil:
+    deallocShared(proof)
+
+proc copyInto*(dest: var G1, src: G1) =
+  copyMem(addr dest.x[0], addr src.x[0], 32)
+  copyMem(addr dest.y[0], addr src.y[0], 32)
+
+proc copyInto*(dest: var G2, src: G2) =
+  for i in 0 .. 1:
+    copyMem(addr dest.x[i][0], addr src.x[i][0], 32)
+    copyMem(addr dest.y[i][0], addr src.y[i][0], 32)
+
+proc copyProof*(dest: ptr Proof, src: Proof) =
+  if not isNil(dest):
+    copyInto(dest.a, src.a)
+    copyInto(dest.b, src.b)
+    copyInto(dest.c, src.c)

--- a/codex/slots/proofs/backendutils.nim
+++ b/codex/slots/proofs/backendutils.nim
@@ -1,8 +1,13 @@
 import ./backends
+import pkg/taskpools
 
 type BackendUtils* = ref object of RootObj
 
 method initializeCircomBackend*(
-    self: BackendUtils, r1csFile: string, wasmFile: string, zKeyFile: string
+    self: BackendUtils,
+    r1csFile: string,
+    wasmFile: string,
+    zKeyFile: string,
+    taskpool: Taskpool,
 ): AnyBackend {.base, gcsafe.} =
-  CircomCompat.init(r1csFile, wasmFile, zKeyFile)
+  CircomCompat.init(r1csFile, wasmFile, zKeyFile, taskpool = taskpool)

--- a/codex/slots/proofs/prover.nim
+++ b/codex/slots/proofs/prover.nim
@@ -72,7 +72,7 @@ proc prove*(
     return failure(err)
 
   # prove slot
-  without proof =? self.backend.prove(proofInput), err:
+  without proof =? await self.backend.prove(proofInput), err:
     error "Unable to prove slot", err = err.msg
     return failure(err)
 
@@ -83,7 +83,11 @@ proc verify*(
 ): Future[?!bool] {.async.} =
   ## Prove a statement using backend.
   ## Returns a future that resolves to a proof.
-  self.backend.verify(proof, inputs)
+  without res =? (await self.backend.verify(proof, inputs)), err:
+    error "Unable to verify proof", err = err.msg
+    return failure(err)
+
+  return success(res)
 
 proc new*(
     _: type Prover, store: BlockStore, backend: AnyBackend, nSamples: int

--- a/tests/codex/slots/testbackendfactory.nim
+++ b/tests/codex/slots/testbackendfactory.nim
@@ -4,6 +4,7 @@ import ../../asynctest
 import pkg/chronos
 import pkg/confutils/defs
 import pkg/codex/conf
+import pkg/taskpools
 import pkg/codex/slots/proofs/backends
 import pkg/codex/slots/proofs/backendfactory
 import pkg/codex/slots/proofs/backendutils
@@ -18,7 +19,11 @@ type BackendUtilsMock = ref object of BackendUtils
   argZKeyFile: string
 
 method initializeCircomBackend*(
-    self: BackendUtilsMock, r1csFile: string, wasmFile: string, zKeyFile: string
+    self: BackendUtilsMock,
+    r1csFile: string,
+    wasmFile: string,
+    zKeyFile: string,
+    taskpool: Taskpool,
 ): AnyBackend =
   self.argR1csFile = r1csFile
   self.argWasmFile = wasmFile

--- a/tests/codex/slots/testbackendfactory.nim
+++ b/tests/codex/slots/testbackendfactory.nim
@@ -52,7 +52,7 @@ suite "Test BackendFactory":
         circomWasm: InputFile("tests/circuits/fixtures/proof_main.wasm"),
         circomZkey: InputFile("tests/circuits/fixtures/proof_main.zkey"),
       )
-      backend = config.initializeBackend(utilsMock).tryGet
+      backend = config.initializeBackend(utilsMock, taskpool = nil).tryGet
 
     check:
       backend.vkp != nil
@@ -73,7 +73,7 @@ suite "Test BackendFactory":
         # will be picked up as local files:
         circuitDir: OutDir("tests/circuits/fixtures"),
       )
-      backend = config.initializeBackend(utilsMock).tryGet
+      backend = config.initializeBackend(utilsMock, taskpool = nil).tryGet
 
     check:
       backend.vkp != nil
@@ -91,7 +91,7 @@ suite "Test BackendFactory":
         marketplaceAddress: EthAddress.example.some,
         circuitDir: OutDir(circuitDir),
       )
-      backendResult = config.initializeBackend(utilsMock)
+      backendResult = config.initializeBackend(utilsMock, taskpool = nil)
 
     check:
       backendResult.isErr

--- a/tests/codex/slots/testprover.nim
+++ b/tests/codex/slots/testprover.nim
@@ -166,4 +166,4 @@ suite "Test Prover":
       check exc of CancelledError
     finally:
       # validate the verifyResponse 
-      check verifyRes[].load() == true
+      check verifyRes[] == true

--- a/tests/codex/slots/testprover.nim
+++ b/tests/codex/slots/testprover.nim
@@ -1,6 +1,5 @@
 import ../../asynctest
 
-import std/atomics
 import pkg/chronos
 import pkg/libp2p/cid
 

--- a/tests/codex/slots/testprover.nim
+++ b/tests/codex/slots/testprover.nim
@@ -121,7 +121,7 @@ suite "Test Prover":
 
     for i in 0 ..< verifyResults.len:
       check:
-        verifyResults[i].read().isErr == false
+        verifyResults[i].read().tryGet() == true
 
   test "Should complete prove/verify task when cancelled":
     let (_, _, verifiable) = await createVerifiableManifest(
@@ -135,7 +135,7 @@ suite "Test Prover":
 
     let (inputs, proof) = (await prover.prove(1, verifiable, challenge)).tryGet
 
-    var cancelledProof = newProof()
+    var cancelledProof = ProofPtr.new()
     defer:
       destroyProof(cancelledProof)
 
@@ -152,7 +152,7 @@ suite "Test Prover":
       check:
         (await prover.verify(cancelledProof[], inputs)).tryGet == true
 
-    var verifyRes = newVerifyResult()
+    var verifyRes = VerifyResult.new()
     defer:
       destroyVerifyResult(verifyRes)
 


### PR DESCRIPTION
This PR adds multi-threading support to the circompat backend to prevent blocking during proof generation and verification.