### PR TITLE
experiment of moving storing the block and its metadata to NetworkStore

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -396,28 +396,8 @@ proc blocksDeliveryHandler*(
       peer = peer
       address = bd.address
 
-    try:
-      if err =? self.validateBlockDelivery(bd).errorOption:
-        warn "Block validation failed", msg = err.msg
-        continue
-
-      if err =? (await self.localStore.putBlock(bd.blk)).errorOption:
-        error "Unable to store block", err = err.msg
-        continue
-
-      if bd.address.leaf:
-        without proof =? bd.proof:
-          warn "Proof expected for a leaf block delivery"
-          continue
-        if err =? (
-          await self.localStore.putCidAndProof(
-            bd.address.treeCid, bd.address.index, bd.blk.cid, proof
-          )
-        ).errorOption:
-          warn "Unable to store proof and cid for a block"
-          continue
-    except CatchableError as exc:
-      warn "Error handling block delivery", error = exc.msg
+    if err =? self.validateBlockDelivery(bd).errorOption:
+      warn "Block validation failed", msg = err.msg
       continue
 
     validatedBlocksDelivery.add(bd)

--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -16,6 +16,7 @@ import std/strutils
 import pkg/chronos
 import pkg/libp2p
 import pkg/metrics
+import pkg/questionable/results
 
 import ../protobuf/blockexc
 import ../../blocktype
@@ -104,6 +105,9 @@ proc resolve*(
           startTime = blockReq[].startTime
           stopTime = getMonoTime().ticks
           retrievalDurationUs = (stopTime - startTime) div 1000
+
+        if bd.proof.isSome:
+          bd.blk.proof = bd.proof
 
         blockReq.handle.complete(bd.blk)
 

--- a/codex/blocktype.nim
+++ b/codex/blocktype.nim
@@ -28,6 +28,7 @@ import ./errors
 import ./logutils
 import ./utils/json
 import ./codextypes
+from ./merkletree/codex/codex import CodexProof
 
 export errors, logutils, units, codextypes
 
@@ -35,6 +36,7 @@ type
   Block* = ref object of RootObj
     cid*: Cid
     data*: seq[byte]
+    proof*: ?CodexProof
 
   BlockAddress* = object
     case leaf*: bool

--- a/codex/merkletree/codex/codex.nim
+++ b/codex/merkletree/codex/codex.nim
@@ -20,6 +20,7 @@ import ../../utils
 import ../../rng
 import ../../errors
 import ../../blocktype
+import ../../codextypes
 
 from ../../utils/digest import digestBytes
 


### PR DESCRIPTION
Just a place for some experiments and discussions...

Thinking aloud - should the block exchange engine use local store as dependencies? For instance, should the blocks be immediately stored to the local store on receiving blocks deliveries or should it be left to the upper layer (e.g. NetworkStore to make that decision). This way ignoring some "troublesome" blocks would be easier, without going through the store/delete cycle.
