### PR TITLE
ci: validate pr title to adhere conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/pr-conventional-commits@1.4.1
+        with:
+          task_types: '["feat","fix","docs","test","ci","build","refactor","style","perf","chore","revert"]'
+
   matrix:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
PR intends to implement a PR title check for CI workflow for #1253.

It works in the following way
1. User create a PR
2. All workflow jobs are run including `pr-title`, which was added in this PR
3. Job `pr-title` is mandatory to pass branch status check
4. When PR title is not align wit the rules, we should edit it and make a force-push to re-run `pr-title` job

> [!NOTE]
> We will add `pr-title` job to the branch protection rules only after this PR will be merged.