### PR TITLE
ci(docker): add stable tag for dist-tests images

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -49,6 +49,7 @@ jobs:
       nat_ip_auto: true
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
       tag_suffix: dist-tests
+      tag_stable: ${{ startsWith(github.ref, 'refs/tags/') }}
       contract_image: "codexstorage/codex-contracts-eth:sha-${{ needs.get-contracts-hash.outputs.hash }}-dist-tests"
       run_release_tests: ${{ inputs.run_release_tests }}
     secrets: inherit


### PR DESCRIPTION
This is a https://github.com/codex-storage/nim-codex/pull/1265 follow up and it adds a `stable` tag for dists-tests Docker images as well - `codexstorage/nim-codex:stable-dists-tests`.

That is useful for Testnet where we are running latest release (`stable`).