### PR TITLE
fix: Disable erasure early exit during streaming to prevent cancellation conflicts

### DIFF
--- a/codex/node.nim
+++ b/codex/node.nim
@@ -296,7 +296,10 @@ proc streamEntireDataset(
         let erasure = Erasure.new(
           self.networkStore, leoEncoderProvider, leoDecoderProvider, self.taskpool
         )
-        without _ =? (await erasure.decode(manifest)), error:
+        # when streaming, erasure acts as a prefetching helper rather than
+        # trying to exit early. The early exit optimization is less valuable
+        # when the client needs most blocks anyway.
+        without _ =? (await erasure.decode(manifest, allowEarlyExit = false)), error:
           error "Unable to erasure decode manifest", manifestCid, exc = error.msg
       except CatchableError as exc:
         trace "Error erasure decoding manifest", manifestCid, exc = exc.msg


### PR DESCRIPTION
When streamEntireDataset() runs background erasure decoding while client streams blocks, erasure early exit was cancelling downloads that the streaming client still needed, causing CancelledError failures.

Add allowEarlyExit parameter to erasure.decode() and disable it during streaming. This makes the background erasure job act as a prefetching helper rather than competing with client reads for the same blocks.

The early exit optimization is less valuable during streaming since the client typically needs most blocks anyway, and cooperative prefetching provides better user experience than download cancellation conflicts.