### PR TITLE
fix: resolve shared block request cancellation conflicts

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -230,6 +230,12 @@ proc requestBlock*(
 ): Future[?!Block] {.async: (raw: true, raises: [CancelledError]).} =
   self.requestBlock(BlockAddress.init(cid))
 
+proc completeBlock*(self: BlockExcEngine, address: BlockAddress, blk: Block) =
+  if address in self.pendingBlocks.blocks:
+    self.pendingBlocks.completeWantHandle(address, blk)
+  else:
+    warn "Attempted to complete non-pending block", address
+
 proc blockPresenceHandler*(
     self: BlockExcEngine, peer: PeerId, blocks: seq[BlockPresence]
 ) {.async: (raises: []).} =

--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -90,6 +90,19 @@ proc getWantHandle*(
 ): Future[Block] {.async: (raw: true, raises: [CancelledError, RetriesExhaustedError]).} =
   self.getWantHandle(BlockAddress.init(cid), inFlight)
 
+proc completeWantHandle*(
+    self: PendingBlocksManager, address: BlockAddress, blk: Block
+) {.raises: [].} =
+  ## Complete a pending want handle
+  self.blocks.withValue(address, blockReq):
+    if not blockReq[].handle.finished:
+      trace "Completing want handle from provided block", address
+      blockReq[].handle.complete(blk)
+    else:
+      trace "Want handle already completed", address
+  do:
+    trace "No pending want handle found for address", address
+
 proc resolve*(
     self: PendingBlocksManager, blocksDelivery: seq[BlockDelivery]
 ) {.gcsafe, raises: [].} =

--- a/codex/stores/blockstore.nim
+++ b/codex/stores/blockstore.nim
@@ -65,6 +65,11 @@ method getBlock*(
 
   raiseAssert("getBlock by addr not implemented!")
 
+method completeBlock*(
+    self: BlockStore, address: BlockAddress, blk: Block
+) {.base, gcsafe.} =
+  discard
+
 method getBlockAndProof*(
     self: BlockStore, treeCid: Cid, index: Natural
 ): Future[?!(Block, CodexProof)] {.base, async: (raises: [CancelledError]), gcsafe.} =

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -259,6 +259,9 @@ method delBlock*(
 
   return success()
 
+method completeBlock*(self: CacheStore, address: BlockAddress, blk: Block) {.gcsafe.} =
+  discard
+
 method close*(self: CacheStore): Future[void] {.async: (raises: []).} =
   ## Close the blockstore, a no-op for this implementation
   ##

--- a/codex/stores/networkstore.nim
+++ b/codex/stores/networkstore.nim
@@ -63,6 +63,9 @@ method getBlock*(
 
   self.getBlock(BlockAddress.init(treeCid, index))
 
+method completeBlock*(self: NetworkStore, address: BlockAddress, blk: Block) =
+  self.engine.completeBlock(address, blk)
+
 method putBlock*(
     self: NetworkStore, blk: Block, ttl = Duration.none
 ): Future[?!void] {.async: (raises: [CancelledError]).} =


### PR DESCRIPTION
Multiple components requesting the same blocks share the same Future instance, causing cancellation by one component (e.g., erasure) to fail all others with CancelledError.

- Remove block request cancellation in erasure decoding
- Add completeBlock() to allow erasure to fulfill pending requests with recovered blocks

Erasure no longer cancels shared futures and instead provides recovered blocks to other waiting components avoiding conflicts.