### PR TITLE
chore(ci): bump node to v22

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           MSYS2_PATH_TYPE: inherit
         run: |
-          npm install
+          npm ci
           npm start &
           # Wait for the contracts to be deployed
           sleep 5


### PR DESCRIPTION
PR closes https://github.com/codex-storage/nim-codex/issues/1240 and updates node to 22, because https://github.com/codex-storage/codex-contracts-eth/pull/231 was already merged.

Also, it was observed that the step `Setup Node.js` is not required for unittest.

And Adam pointed out that we have to use `npm ci` instead of `install` like we did on https://github.com/codex-storage/codex-contracts-eth/pull/244 and https://github.com/codex-storage/codex-marketplace-ui/pull/108.