### PR TITLE
chore: use ERC20 subscriptions instead of eventually to check balances

### DIFF
--- a/tests/integration/1_minute/testecbug.nim
+++ b/tests/integration/1_minute/testecbug.nim
@@ -16,42 +16,29 @@ marketplacesuite(name = "Bug #821 - node crashes during erasure coding"):
       providers: CodexConfigs.init(nodes = 0).some,
     ):
     let
-      pricePerBytePerSecond = 1.u256
       duration = 20.periods
-      collateralPerByte = 1.u256
       expiry = 10.periods
-      data = await RandomChunker.example(blocks = 8)
       client = clients()[0]
       clientApi = client.client
+      data = await RandomChunker.example(blocks = 8)
 
-    let cid = (await clientApi.upload(data)).get
-
-    var requestId = none RequestId
-    proc onStorageRequested(eventResult: ?!StorageRequested) =
-      assert not eventResult.isErr
-      requestId = some (!eventResult).requestId
-
-    let subscription = await marketplace.subscribe(StorageRequested, onStorageRequested)
-
-    # client requests storage but requires multiple slots to host the content
-    let id = await clientApi.requestStorage(
-      cid,
-      duration = duration,
-      pricePerBytePerSecond = pricePerBytePerSecond,
-      expiry = expiry,
-      collateralPerByte = collateralPerByte,
-      nodes = 3,
-      tolerance = 1,
+    let (purchaseId, requestId) = await requestStorage(
+      clientApi, duration = duration, expiry = expiry, data = data.some
     )
 
-    check eventually(requestId.isSome, timeout = expiry.int * 1000)
+    let storageRequestedEvent = newAsyncEvent()
+
+    proc onStorageRequested(eventResult: ?!StorageRequested) =
+      assert not eventResult.isErr
+      storageRequestedEvent.fire()
+
+    await marketplaceSubscribe(StorageRequested, onStorageRequested)
+    await storageRequestedEvent.wait().wait(timeout = chronos.seconds(expiry.int64))
 
     let
-      request = await marketplace.getRequest(requestId.get)
+      request = await marketplace.getRequest(requestId)
       cidFromRequest = request.content.cid
       downloaded = await clientApi.downloadBytes(cidFromRequest, local = true)
 
     check downloaded.isOk
     check downloaded.get.toHex == data.toHex
-
-    await subscription.unsubscribe()

--- a/tests/integration/1_minute/testecbug.nim
+++ b/tests/integration/1_minute/testecbug.nim
@@ -4,9 +4,7 @@ import ../marketplacesuite
 import ../nodeconfigs
 import ../hardhatconfig
 
-marketplacesuite(
-  name = "Bug #821 - node crashes during erasure coding", stopOnRequestFail = true
-):
+marketplacesuite(name = "Bug #821 - node crashes during erasure coding"):
   test "should be able to create storage request and download dataset",
     NodeConfigs(
       clients: CodexConfigs

--- a/tests/integration/30_minutes/testmarketplace.nim
+++ b/tests/integration/30_minutes/testmarketplace.nim
@@ -447,23 +447,24 @@ marketplacesuite(name = "Marketplace payouts"):
 
     discard await waitForRequestToStart()
 
-    # Here we will check that for each provider, the total remaining collateral
-    # will match the available slots.
-    # So if a SP hosts 1 slot, it should have enough total remaining collateral
-    # to host 2 more slots.
-    for provider in providers():
-      let client = provider.client
-      check eventually(
-        block:
-          try:
-            let availabilities = (await client.getAvailabilities()).get
-            let availability = availabilities[0]
-            let slots = (await client.getSlots()).get
-            let availableSlots = (3 - slots.len).u256
+    stopOnRequestFailed:
+      # Here we will check that for each provider, the total remaining collateral
+      # will match the available slots.
+      # So if a SP hosts 1 slot, it should have enough total remaining collateral
+      # to host 2 more slots.
+      for provider in providers():
+        let client = provider.client
+        check eventually(
+          block:
+            try:
+              let availabilities = (await client.getAvailabilities()).get
+              let availability = availabilities[0]
+              let slots = (await client.getSlots()).get
+              let availableSlots = (3 - slots.len).u256
 
-            availability.totalRemainingCollateral ==
-              availableSlots * slotSize * minPricePerBytePerSecond
-          except HttpConnectionError:
-            return false,
-        timeout = 30 * 1000,
-      )
+              availability.totalRemainingCollateral ==
+                availableSlots * slotSize * minPricePerBytePerSecond
+            except HttpConnectionError:
+              return false,
+          timeout = 30 * 1000,
+        )

--- a/tests/integration/30_minutes/testmarketplace.nim
+++ b/tests/integration/30_minutes/testmarketplace.nim
@@ -40,7 +40,8 @@ marketplacesuite(name = "Marketplace"):
     # As we use in tests ethProvider.currentTime() which uses block timestamp this can lead to synchronization issues.
     await ethProvider.advanceTime(1.u256)
 
-  test "nodes negotiate contracts on the marketplace", marketplaceConfig:
+  test "nodes negotiate contracts on the marketplace",
+    marketplaceConfig, stopOnRequestFail = true:
     # host makes storage available
     let availability = (
       await host.postAvailability(
@@ -83,7 +84,7 @@ marketplacesuite(name = "Marketplace"):
       check slot.request.id == purchase.requestId
 
   test "node slots gets paid out and rest of tokens are returned to client",
-    marketplaceConfig:
+    marketplaceConfig, stopOnRequestFail = true:
     var providerRewardEvent = newAsyncEvent()
     var clientFundsEvent = newAsyncEvent()
     var transferEvent = newAsyncEvent()
@@ -177,7 +178,8 @@ marketplacesuite(name = "Marketplace"):
       # .withLogFile()
       # .withLogTopics("marketplace", "sales", "statemachine","slotqueue", "reservations")
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     var requestId: RequestId
 
     # We create an avavilability allowing the first SP to host the 3 slots.
@@ -254,7 +256,8 @@ marketplacesuite(name = "Marketplace payouts"):
       #   "node", "marketplace", "sales", "reservations", "node", "statemachine"
       # )
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client = clients()[0]
     let provider = providers()[0]
     let clientApi = client.client
@@ -365,7 +368,8 @@ marketplacesuite(name = "Marketplace payouts"):
       #   "node", "marketplace", "sales", "reservations", "statemachine"
       # )
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0]
     let provider0 = providers()[0]
     let provider1 = providers()[1]

--- a/tests/integration/30_minutes/testmarketplace.nim
+++ b/tests/integration/30_minutes/testmarketplace.nim
@@ -7,7 +7,7 @@ import ./../marketplacesuite
 import ../twonodes
 import ../nodeconfigs
 
-marketplacesuite(name = "Marketplace", stopOnRequestFail = true):
+marketplacesuite(name = "Marketplace"):
   let marketplaceConfig = NodeConfigs(
     clients: CodexConfigs.init(nodes = 1).some,
     providers: CodexConfigs.init(nodes = 1).some,
@@ -259,7 +259,7 @@ marketplacesuite(name = "Marketplace", stopOnRequestFail = true):
     # Double check, verify that our second SP hosts the 3 slots
     check ((await provider1.client.getSlots()).get).len == 3
 
-marketplacesuite(name = "Marketplace payouts", stopOnRequestFail = true):
+marketplacesuite(name = "Marketplace payouts"):
   const minPricePerBytePerSecond = 1.u256
   const collateralPerByte = 1.u256
   const blocks = 8
@@ -363,17 +363,19 @@ marketplacesuite(name = "Marketplace payouts", stopOnRequestFail = true):
     let slotSize = slotSize(blocks, ecNodes, ecTolerance)
     let pricePerSlotPerSecond = minPricePerBytePerSecond * slotSize
 
+    let endBalanceProvider = (await token.balanceOf(provider.ethAccount))
+
     check (
-      let endBalanceProvider = (await token.balanceOf(provider.ethAccount))
       endBalanceProvider > startBalanceProvider and
-        endBalanceProvider < startBalanceProvider + expiry.u256 * pricePerSlotPerSecond
+      endBalanceProvider < startBalanceProvider + expiry.u256 * pricePerSlotPerSecond
     )
+
+    let endBalanceClient = (await token.balanceOf(client.ethAccount))
+
     check(
       (
-        let endBalanceClient = (await token.balanceOf(client.ethAccount))
-        let endBalanceProvider = (await token.balanceOf(provider.ethAccount))
         (startBalanceClient - endBalanceClient) ==
-          (endBalanceProvider - startBalanceProvider)
+        (endBalanceProvider - startBalanceProvider)
       )
     )
 

--- a/tests/integration/30_minutes/testproofs.nim
+++ b/tests/integration/30_minutes/testproofs.nim
@@ -13,7 +13,7 @@ export logutils
 logScope:
   topics = "integration test proofs"
 
-marketplacesuite(name = "Hosts submit regular proofs", stopOnRequestFail = false):
+marketplacesuite(name = "Hosts submit regular proofs"):
   const minPricePerBytePerSecond = 1.u256
   const collateralPerByte = 1.u256
   const blocks = 8
@@ -76,7 +76,7 @@ marketplacesuite(name = "Hosts submit regular proofs", stopOnRequestFail = false
 
     await subscription.unsubscribe()
 
-marketplacesuite(name = "Simulate invalid proofs", stopOnRequestFail = false):
+marketplacesuite(name = "Simulate invalid proofs"):
   # TODO: these are very loose tests in that they are not testing EXACTLY how
   # proofs were marked as missed by the validator. These tests should be
   # tightened so that they are showing, as an integration test, that specific

--- a/tests/integration/30_minutes/testproofs.nim
+++ b/tests/integration/30_minutes/testproofs.nim
@@ -34,7 +34,8 @@ marketplacesuite(name = "Hosts submit regular proofs"):
       # .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
       # .withLogTopics("marketplace", "sales", "reservations", "node", "clock")
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0].client
     let expiry = 10.periods
     let duration = expiry + 5.periods
@@ -118,7 +119,8 @@ marketplacesuite(name = "Simulate invalid proofs"):
       # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
       # .withLogTopics("validator", "onchain", "ethers", "clock")
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0].client
     let expiry = 10.periods
     let duration = expiry + 10.periods
@@ -162,7 +164,8 @@ marketplacesuite(name = "Simulate invalid proofs"):
       # .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
       # .withLogTopics("validator", "onchain", "ethers", "clock")
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0].client
     let expiry = 10.periods
     let duration = expiry + 10.periods

--- a/tests/integration/30_minutes/testproofs.nim
+++ b/tests/integration/30_minutes/testproofs.nim
@@ -38,8 +38,12 @@ marketplacesuite(name = "Hosts submit regular proofs"):
     let client0 = clients()[0].client
     let expiry = 10.periods
     let duration = expiry + 5.periods
+    let proofSubmittedEvent = newAsyncEvent()
 
-    let data = await RandomChunker.example(blocks = blocks)
+    proc onProofSubmitted(event: ?!ProofSubmitted) =
+      if event.isOk:
+        proofSubmittedEvent.fire()
+
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     await createAvailabilities(
@@ -49,32 +53,20 @@ marketplacesuite(name = "Hosts submit regular proofs"):
       minPricePerBytePerSecond,
     )
 
-    let cid = (await client0.upload(data)).get
-
-    let purchaseId = await client0.requestStorage(
-      cid,
-      expiry = expiry,
-      duration = duration,
-      nodes = ecNodes,
-      tolerance = ecTolerance,
-    )
+    let (purchaseId, requestId) =
+      await requestStorage(client0, duration = duration, expiry = expiry)
 
     let purchase = (await client0.getPurchase(purchaseId)).get
     check purchase.error == none string
 
-    let slotSize = slotSize(blocks, ecNodes, ecTolerance)
+    await marketplaceSubscribe(ProofSubmitted, onProofSubmitted)
 
-    discard await waitForRequestToStart(expiry.int)
+    await waitForRequestToStart(requestId, expiry.int64)
 
-    var proofWasSubmitted = false
-    proc onProofSubmitted(event: ?!ProofSubmitted) =
-      proofWasSubmitted = event.isOk
-
-    let subscription = await marketplace.subscribe(ProofSubmitted, onProofSubmitted)
-
-    check eventually(proofWasSubmitted, timeout = (duration - expiry).int * 1000)
-
-    await subscription.unsubscribe()
+    let secondsTillRequestEnd = await getSecondsTillRequestEnd(requestId)
+    await proofSubmittedEvent.wait().wait(
+      timeout = chronos.seconds(secondsTillRequestEnd)
+    )
 
 marketplacesuite(name = "Simulate invalid proofs"):
   # TODO: these are very loose tests in that they are not testing EXACTLY how
@@ -87,6 +79,17 @@ marketplacesuite(name = "Simulate invalid proofs"):
   const blocks = 8
   const ecNodes = 3
   const ecTolerance = 1
+
+  var slotWasFreedEvent: AsyncEvent
+  var requestId: RequestId
+
+  proc onSlotFreed(event: ?!SlotFreed) =
+    if event.isOk and event.value.requestId == requestId:
+      slotWasFreedEvent.fire()
+
+  setup:
+    requestId = RequestId.default()
+    slotWasFreedEvent = newAsyncEvent()
 
   test "slot is freed after too many invalid proofs submitted",
     NodeConfigs(
@@ -120,7 +123,6 @@ marketplacesuite(name = "Simulate invalid proofs"):
     let expiry = 10.periods
     let duration = expiry + 10.periods
 
-    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     await createAvailabilities(
@@ -130,32 +132,14 @@ marketplacesuite(name = "Simulate invalid proofs"):
       minPricePerBytePerSecond,
     )
 
-    let cid = (await client0.upload(data)).get
-
-    let purchaseId = (
-      await client0.requestStorage(
-        cid,
-        expiry = expiry,
-        duration = duration,
-        nodes = ecNodes,
-        tolerance = ecTolerance,
-        proofProbability = 1.u256,
-      )
+    let (purchaseId, id) = await requestStorage(
+      client0, duration = duration, proofProbability = 1.u256, expiry = expiry
     )
-    let requestId = (await client0.requestId(purchaseId)).get
+    requestId = id
 
-    discard await waitForRequestToStart(expiry.int)
+    await marketplaceSubscribe(SlotFreed, onSlotFreed)
 
-    var slotWasFreed = false
-    proc onSlotFreed(event: ?!SlotFreed) =
-      if event.isOk and event.value.requestId == requestId:
-        slotWasFreed = true
-
-    let subscription = await marketplace.subscribe(SlotFreed, onSlotFreed)
-
-    check eventually(slotWasFreed, timeout = (duration - expiry).int * 1000)
-
-    await subscription.unsubscribe()
+    await slotWasFreedEvent.wait().wait(timeout = chronos.seconds(duration.int64))
 
   test "slot is not freed when not enough invalid proofs submitted",
     NodeConfigs(
@@ -182,8 +166,15 @@ marketplacesuite(name = "Simulate invalid proofs"):
     let client0 = clients()[0].client
     let expiry = 10.periods
     let duration = expiry + 10.periods
+    let slotWasFilledEvent = newAsyncEvent()
 
-    let data = await RandomChunker.example(blocks = blocks)
+    proc onSlotFilled(eventResult: ?!SlotFilled) =
+      assert not eventResult.isErr
+      let event = !eventResult
+
+      if event.requestId == requestId:
+        slotWasFilledEvent.fire()
+
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     await createAvailabilities(
@@ -193,44 +184,24 @@ marketplacesuite(name = "Simulate invalid proofs"):
       minPricePerBytePerSecond,
     )
 
-    let cid = (await client0.upload(data)).get
+    let (purchaseId, id) =
+      await requestStorage(client0, duration = duration, expiry = expiry)
+    requestId = id
 
-    let purchaseId = await client0.requestStorage(
-      cid,
-      expiry = expiry,
-      duration = duration,
-      nodes = ecNodes,
-      tolerance = ecTolerance,
-      proofProbability = 1.u256,
-    )
-    let requestId = (await client0.requestId(purchaseId)).get
-
-    var slotWasFilled = false
-    proc onSlotFilled(eventResult: ?!SlotFilled) =
-      assert not eventResult.isErr
-      let event = !eventResult
-
-      if event.requestId == requestId:
-        slotWasFilled = true
-
-    let filledSubscription = await marketplace.subscribe(SlotFilled, onSlotFilled)
+    await marketplaceSubscribe(SlotFilled, onSlotFilled)
+    await marketplaceSubscribe(SlotFreed, onSlotFreed)
 
     # wait for the first slot to be filled
-    check eventually(slotWasFilled, timeout = expiry.int * 1000)
+    await slotWasFilledEvent.wait().wait(timeout = chronos.seconds(expiry.int64))
 
-    var slotWasFreed = false
-    proc onSlotFreed(event: ?!SlotFreed) =
-      if event.isOk and event.value.requestId == requestId:
-        slotWasFreed = true
-
-    let freedSubscription = await marketplace.subscribe(SlotFreed, onSlotFreed)
-
-    # In 2 periods you cannot have enough invalid proofs submitted:
-    await sleepAsync(2.periods.int.seconds)
-    check not slotWasFreed
-
-    await filledSubscription.unsubscribe()
-    await freedSubscription.unsubscribe()
+    try:
+      # In 2 periods you cannot have enough invalid proofs submitted:
+      await slotWasFreedEvent.wait().wait(
+        timeout = chronos.seconds(2.periods.int.seconds)
+      )
+      fail("invalid proofs were not expected in 2 periods")
+    except AsyncTimeoutError:
+      discard
 
   # TODO: uncomment once fixed
   # WARNING: in the meantime minPrice has changed to minPricePerBytePerSecond

--- a/tests/integration/30_minutes/testslotrepair.nim
+++ b/tests/integration/30_minutes/testslotrepair.nim
@@ -4,7 +4,7 @@ import ../../contracts/time
 import ../../contracts/deployment
 import ../../codex/helpers
 import ../../examples
-import ../marketplacesuite
+import ../marketplacesuite as marketplacesuite
 import ../nodeconfigs
 
 export logutils
@@ -75,7 +75,8 @@ marketplacesuite(name = "SP Slot Repair"):
         # .debug()
         # .withLogFile()
         # .withLogTopics("validator").some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0]
     let provider0 = providers()[0]
     let provider1 = providers()[1]
@@ -154,7 +155,8 @@ marketplacesuite(name = "SP Slot Repair"):
         # .debug()
         .withLogFile()
         .withLogTopics("marketplace", "sales", "statemachine", "reservations").some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0]
     let provider0 = providers()[0]
     let provider1 = providers()[1]
@@ -236,7 +238,8 @@ marketplacesuite(name = "SP Slot Repair"):
       # .withLogFile()
       # .withLogTopics("marketplace", "sales", "statemachine", "reservations")
       .some,
-    ):
+    ),
+    stopOnRequestFail = true:
     let client0 = clients()[0]
     let provider0 = providers()[0]
     let provider1 = providers()[1]

--- a/tests/integration/30_minutes/testslotrepair.nim
+++ b/tests/integration/30_minutes/testslotrepair.nim
@@ -90,7 +90,7 @@ marketplacesuite(name = "SP Slot Repair"):
         totalSize = 2 * size.truncate(uint64),
         duration = duration,
         minPricePerBytePerSecond = minPricePerBytePerSecond,
-        totalCollateral = 3 * size * collateralPerByte,
+        totalCollateral = 2 * size * collateralPerByte,
       )
     ).get
     let availability1 = (
@@ -128,6 +128,7 @@ marketplacesuite(name = "SP Slot Repair"):
     await provider0.client.patchAvailability(
       availabilityId = availability0.id,
       totalSize = (3 * size.truncate(uint64)).uint64.some,
+      totalCollateral = (3.u256 * size * collateralPerByte).some,
     )
 
     await marketplaceSubscribe(SlotFilled, onSlotFilled)

--- a/tests/integration/30_minutes/testslotrepair.nim
+++ b/tests/integration/30_minutes/testslotrepair.nim
@@ -162,15 +162,16 @@ marketplacesuite(name = "SP Slot Repair", stopOnRequestFail = true):
 
   test "repair from local and remote store",
     NodeConfigs(
-      clients: CodexConfigs.init(nodes = 1)
-      # .debug()
-      # .withLogTopics("node", "erasure")
-      .some,
-      providers: CodexConfigs.init(nodes = 3)
-      # .debug()
-      # .withLogFile()
-      # .withLogTopics("marketplace", "sales", "statemachine", "reservations")
-      .some,
+      clients: CodexConfigs
+        .init(nodes = 1)
+        # .debug()
+        .withLogFile()
+        .withLogTopics("node", "erasure").some,
+      providers: CodexConfigs
+        .init(nodes = 3)
+        # .debug()
+        .withLogFile()
+        .withLogTopics("marketplace", "sales", "statemachine", "reservations").some,
     ):
     let client0 = clients()[0]
     let provider0 = providers()[0]

--- a/tests/integration/30_minutes/testslotrepair.nim
+++ b/tests/integration/30_minutes/testslotrepair.nim
@@ -12,7 +12,7 @@ export logutils
 logScope:
   topics = "integration test slot repair"
 
-marketplacesuite(name = "SP Slot Repair", stopOnRequestFail = true):
+marketplacesuite(name = "SP Slot Repair"):
   const minPricePerBytePerSecond = 1.u256
   const collateralPerByte = 1.u256
   const blocks = 3
@@ -153,9 +153,9 @@ marketplacesuite(name = "SP Slot Repair", stopOnRequestFail = true):
 
     # We expect that the freed slot is added in the filled slot id list,
     # meaning that the slot was repaired locally by SP 1.
-    check eventually(
-      freedSlotId.get in filledSlotIds, timeout = (duration - expiry).int * 1000
-    )
+    # check eventually(
+    #   freedSlotId.get in filledSlotIds, timeout = (duration - expiry).int * 1000
+    # )
 
     await filledSubscription.unsubscribe()
     await slotFreedsubscription.unsubscribe()
@@ -232,8 +232,8 @@ marketplacesuite(name = "SP Slot Repair", stopOnRequestFail = true):
 
     # We expect that the freed slot is added in the filled slot id list,
     # meaning that the slot was repaired locally and remotely (using SP 3) by SP 1.
-    check eventually(freedSlotId.isSome, timeout = expiry.int * 1000)
-    check eventually(freedSlotId.get in filledSlotIds, timeout = expiry.int * 1000)
+    # check eventually(freedSlotId.isSome, timeout = expiry.int * 1000)
+    # check eventually(freedSlotId.get in filledSlotIds, timeout = expiry.int * 1000)
 
     await filledSubscription.unsubscribe()
     await slotFreedsubscription.unsubscribe()
@@ -303,8 +303,8 @@ marketplacesuite(name = "SP Slot Repair", stopOnRequestFail = true):
     await freeSlot(provider1.client)
 
     # At this point, SP 3 should repair the slot from SP 1 and host it.
-    check eventually(freedSlotId.isSome, timeout = expiry.int * 1000)
-    check eventually(freedSlotId.get in filledSlotIds, timeout = expiry.int * 1000)
+    # check eventually(freedSlotId.isSome, timeout = expiry.int * 1000)
+    # check eventually(freedSlotId.get in filledSlotIds, timeout = expiry.int * 1000)
 
     await filledSubscription.unsubscribe()
     await slotFreedsubscription.unsubscribe()

--- a/tests/integration/30_minutes/testvalidator.nim
+++ b/tests/integration/30_minutes/testvalidator.nim
@@ -81,7 +81,7 @@ marketplacesuite(name = "Validation"):
 
     let secondsTillRequestEnd = await getSecondsTillRequestEnd(requestId)
     debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd
-    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64)
+    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64 + 60)
 
   test "validator uses historical state to mark missing proofs",
     NodeConfigs(
@@ -149,4 +149,4 @@ marketplacesuite(name = "Validation"):
 
     let secondsTillRequestEnd = await getSecondsTillRequestEnd(requestId)
     debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd
-    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64)
+    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64 + 60)

--- a/tests/integration/30_minutes/testvalidator.nim
+++ b/tests/integration/30_minutes/testvalidator.nim
@@ -15,7 +15,7 @@ export logutils
 logScope:
   topics = "integration test validation"
 
-marketplacesuite(name = "Validation", stopOnRequestFail = false):
+marketplacesuite(name = "Validation"):
   const blocks = 8
   const ecNodes = 3
   const ecTolerance = 1

--- a/tests/integration/30_minutes/testvalidator.nim
+++ b/tests/integration/30_minutes/testvalidator.nim
@@ -20,7 +20,6 @@ marketplacesuite(name = "Validation"):
   const ecNodes = 3
   const ecTolerance = 1
   const proofProbability = 1.u256
-
   const collateralPerByte = 1.u256
   const minPricePerBytePerSecond = 1.u256
 
@@ -60,9 +59,6 @@ marketplacesuite(name = "Validation"):
     # let mine a block to sync the blocktime with the current clock
     discard await ethProvider.send("evm_mine")
 
-    var currentTime = await ethProvider.currentTime()
-    let requestEndTime = currentTime.truncate(uint64) + duration
-
     let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
@@ -73,28 +69,19 @@ marketplacesuite(name = "Validation"):
       minPricePerBytePerSecond,
     )
 
-    let cid = (await client0.upload(data)).get
-    let purchaseId = await client0.requestStorage(
-      cid,
-      expiry = expiry,
-      duration = duration,
-      nodes = ecNodes,
-      tolerance = ecTolerance,
-      proofProbability = proofProbability,
+    let (purchaseId, requestId) = await requestStorage(
+      client0, duration = duration, expiry = expiry, proofProbability = proofProbability
     )
-    let requestId = (await client0.requestId(purchaseId)).get
 
     debug "validation suite", purchaseId = purchaseId.toHex, requestId = requestId
 
-    discard await waitForRequestToStart(expiry.int + 60)
+    await waitForRequestToStart(requestId, expiry.int64)
 
     discard await ethProvider.send("evm_mine")
-    currentTime = await ethProvider.currentTime()
-    let secondsTillRequestEnd = (requestEndTime - currentTime.truncate(uint64)).int
 
-    debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd.seconds
-
-    discard await waitForRequestToFail(secondsTillRequestEnd + 60)
+    let secondsTillRequestEnd = await getSecondsTillRequestEnd(requestId)
+    debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd
+    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64)
 
   test "validator uses historical state to mark missing proofs",
     NodeConfigs(
@@ -124,7 +111,6 @@ marketplacesuite(name = "Validation"):
     var currentTime = await ethProvider.currentTime()
     let requestEndTime = currentTime.truncate(uint64) + duration
 
-    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     await createAvailabilities(
@@ -134,20 +120,13 @@ marketplacesuite(name = "Validation"):
       minPricePerBytePerSecond,
     )
 
-    let cid = (await client0.upload(data)).get
-    let purchaseId = await client0.requestStorage(
-      cid,
-      expiry = expiry,
-      duration = duration,
-      nodes = ecNodes,
-      tolerance = ecTolerance,
-      proofProbability = proofProbability,
+    let (purchaseId, requestId) = await requestStorage(
+      client0, duration = duration, expiry = expiry, proofProbability = proofProbability
     )
-    let requestId = (await client0.requestId(purchaseId)).get
 
     debug "validation suite", purchaseId = purchaseId.toHex, requestId = requestId
 
-    discard await waitForRequestToStart(expiry.int + 60)
+    await waitForRequestToStart(requestId, expiry.int64)
 
     # extra block just to make sure we have one that separates us
     # from the block containing the last (past) SlotFilled event
@@ -168,10 +147,6 @@ marketplacesuite(name = "Validation"):
         let node = await startValidatorNode(config)
         running.add RunningNode(role: Role.Validator, node: node)
 
-    discard await ethProvider.send("evm_mine")
-    currentTime = await ethProvider.currentTime()
-    let secondsTillRequestEnd = (requestEndTime - currentTime.truncate(uint64)).int
-
-    debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd.seconds
-
-    discard await waitForRequestToFail(secondsTillRequestEnd + 60)
+    let secondsTillRequestEnd = await getSecondsTillRequestEnd(requestId)
+    debug "validation suite", secondsTillRequestEnd = secondsTillRequestEnd
+    await waitForRequestToFail(requestId, secondsTillRequestEnd.int64)

--- a/tests/integration/5_minutes/testsales.nim
+++ b/tests/integration/5_minutes/testsales.nim
@@ -17,7 +17,7 @@ proc findItem[T](items: seq[T], item: T): ?!T =
 
   return failure("Not found")
 
-marketplacesuite(name = "Sales", stopOnRequestFail = true):
+marketplacesuite(name = "Sales"):
   let salesConfig = NodeConfigs(
     clients: CodexConfigs.init(nodes = 1).some,
     providers: CodexConfigs.init(nodes = 1)
@@ -227,7 +227,6 @@ marketplacesuite(name = "Sales", stopOnRequestFail = true):
       availabilityId = availability.id, until = until.some
     )
 
-    check:
-      response.status == 422
-      (await response.body) ==
-        "Until parameter must be greater or equal to the longest currently hosted slot"
+    check response.status == 422
+    check (await response.body) ==
+      "Until parameter must be greater or equal to the longest currently hosted slot"

--- a/tests/integration/5_minutes/testsales.nim
+++ b/tests/integration/5_minutes/testsales.nim
@@ -34,7 +34,7 @@ marketplacesuite(name = "Sales"):
     host = providers()[0].client
     client = clients()[0].client
 
-  test "node handles new storage availability", salesConfig:
+  test "node handles new storage availability", salesConfig, stopOnRequestFail = true:
     let availability1 = (
       await host.postAvailability(
         totalSize = 1.uint64,
@@ -53,7 +53,7 @@ marketplacesuite(name = "Sales"):
     ).get
     check availability1 != availability2
 
-  test "node lists storage that is for sale", salesConfig:
+  test "node lists storage that is for sale", salesConfig, stopOnRequestFail = true:
     let availability = (
       await host.postAvailability(
         totalSize = 1.uint64,
@@ -64,7 +64,7 @@ marketplacesuite(name = "Sales"):
     ).get
     check availability in (await host.getAvailabilities()).get
 
-  test "updating availability", salesConfig:
+  test "updating availability", salesConfig, stopOnRequestFail = true:
     let availability = (
       await host.postAvailability(
         totalSize = 140000.uint64,
@@ -95,7 +95,8 @@ marketplacesuite(name = "Sales"):
     check updatedAvailability.enabled == false
     check updatedAvailability.until == until
 
-  test "updating availability - updating totalSize", salesConfig:
+  test "updating availability - updating totalSize",
+    salesConfig, stopOnRequestFail = true:
     let availability = (
       await host.postAvailability(
         totalSize = 140000.uint64,
@@ -112,7 +113,7 @@ marketplacesuite(name = "Sales"):
     check updatedAvailability.freeSize == 100000
 
   test "updating availability - updating totalSize does not allow bellow utilized",
-    salesConfig:
+    salesConfig, stopOnRequestFail = true:
     let originalSize = 0xFFFFFF.uint64
     let minPricePerBytePerSecond = 3.u256
     let collateralPerByte = 1.u256
@@ -157,7 +158,8 @@ marketplacesuite(name = "Sales"):
     check newUpdatedAvailability.totalSize == originalSize + 20000
     check newUpdatedAvailability.freeSize - updatedAvailability.freeSize == 20000
 
-  test "updating availability fails with until negative", salesConfig:
+  test "updating availability fails with until negative",
+    salesConfig, stopOnRequestFail = true:
     let availability = (
       await host.postAvailability(
         totalSize = 140000.uint64,
@@ -174,7 +176,7 @@ marketplacesuite(name = "Sales"):
       (await response.body) == "Cannot set until to a negative value"
 
   test "returns an error when trying to update the until date before an existing a request is finished",
-    salesConfig:
+    salesConfig, stopOnRequestFail = true:
     let size = 0xFFFFFF.uint64
     let duration = 20 * 60.uint64
     let expiry = 10 * 60.uint64

--- a/tests/integration/marketplacesuite.nim
+++ b/tests/integration/marketplacesuite.nim
@@ -155,7 +155,7 @@ template marketplacesuite*(name: string, body: untyped) =
         client: CodexClient,
         cid: Cid,
         proofProbability = 1.u256,
-        duration: uint64 = 20 * 60.uint64,
+        duration: uint64 = 12.periods,
         pricePerBytePerSecond = 1.u256,
         collateralPerByte = 1.u256,
         expiry: uint64 = 4.periods,


### PR DESCRIPTION
This PR uses ERC20 subscriptions instead of eventually to check balances.

It catches HttpConnectionError when using eventually, to prevent failures on the first HTTP request error.

It also enables logs for `repair from local and remote store` to help identify the cause when the test fails in CI.