### PR TITLE
chore: skip marketplace integration tests 

### DIFF
--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -2,13 +2,14 @@ import std/macros
 import std/os
 import std/strutils
 
-macro importTests*(dir: static string): untyped =
+macro importTests*(dir: static string, excludes: static string = ""): untyped =
   ## imports all files in the specified directory whose filename
   ## starts with "test" and ends in ".nim"
   let imports = newStmtList()
+  let excludeList = excludes.split(",")
   for file in walkDirRec(dir):
     let (_, name, ext) = splitFile(file)
-    if name.startsWith("test") and ext == ".nim":
+    if name.startsWith("test") and ext == ".nim" and not (name in excludeList):
       imports.add(
         quote do:
           import `file`

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -12,7 +12,11 @@ when includes != "":
   importAll(includes.split(","))
 else:
   # import all tests in the integration/ directory
-  importTests(currentSourcePath().parentDir() / "integration" / "1_minute")
-  importTests(currentSourcePath().parentDir() / "integration" / "5_minutes")
+  importTests(
+    currentSourcePath().parentDir() / "integration" / "1_minute", "testpurchasing"
+  )
+  importTests(
+    currentSourcePath().parentDir() / "integration" / "5_minutes", "testsales"
+  )
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
This PR skips the Marketplace integration tests (located in the 30-minutes folder).

The tests take around 30 minutes to run and slow to run locally. For now, we are not using Marketplace integrations, so it makes sense to disable them.