### PR TITLE
fix(block exchange): decrements block retries count when downloading with no peers

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -972,7 +972,7 @@ proc blockexcTaskRunner(self: BlockExcEngine) {.async: (raises: []).} =
       let peerCtx = await self.taskQueue.pop()
       await self.taskHandler(peerCtx)
   except CancelledError:
-    trace "block exchange task runner cancelled", peer = peerCtx.id
+    trace "block exchange task runner cancelled"
   except CatchableError as exc:
     error "error running block exchange task", error = exc.msg
 


### PR DESCRIPTION
There is a limitation in `downloadInternal` that infinitely loops for peers when attempting to download a block if the node does not have peers. Currently, the block retry counter is only decremented if there exists peers and a download attempt is made, otherwise the loop will continue until peers are found, ad infinium. This fix decrements the retry counter on each loop that no peers are found. Additionally, it waits for the `DiscoveryRateLimit` interval before retrying, as otherwise looking for peers would not produce new results.
