### PR TITLE
fix: parse config using int for NBytes instead of string

### DIFF
--- a/library/codex_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/codex_thread_requests/requests/node_lifecycle_request.nim
@@ -63,10 +63,7 @@ proc readValue*(r: var JsonReader, val: var ThreadCount) =
   val = res.get()
 
 proc readValue*(r: var JsonReader, val: var NBytes) =
-  let res = NBytes.parse(r.readValue(string))
-  if res.isErr:
-    raise newException(SerializationError, "Cannot parse the NBytes: " & res.error())
-  val = res.get()
+  val = NBytes(r.readValue(int))
 
 proc readValue*(r: var JsonReader, val: var Duration) =
   var dur: Duration


### PR DESCRIPTION
This issue was discovered first [here](https://github.com/codex-storage/codex-go-bindings/issues/12) when trying to use `StoringQuota`. The value expected in the json should be a int and not a string.