### PR TITLE
build(docker): ignore ipv6 for NAT_IP_AUTO

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -63,7 +63,7 @@ fi
 # Parameters
 if [[ -z "${STORAGE_NAT}" ]]; then
   if [[ "${NAT_IP_AUTO}" == "true" && -z "${NAT_PUBLIC_IP_AUTO}" ]]; then
-    export STORAGE_NAT="extip:$(hostname --ip-address)"
+    export STORAGE_NAT="extip:$(hostname --ip-address | grep --color=never -oE '([0-9]{1,3}\.){3}[0-9]{1,3}')"
   elif [[ -n "${NAT_PUBLIC_IP_AUTO}" ]]; then
     # Run for 60 seconds if fail
     WAIT=120


### PR DESCRIPTION
There is support to resolve the local IP automatically and announce that as the public address of the node using the `NAT_IP_AUTO` variable. This is mainly used for Distributed testing. If the Docker container gets assigned both IPv4 and IPv6, then the `hostname -I` returns a string in the format `fd07:b51a:cc66:a::b 192.168.194.11` which is then passed into the client that fails to parse that. This PR fixes this by using only the IPv4 address.