### PR TITLE
chore: clean defaultChroniclesStream on close

### DIFF
--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -96,13 +96,12 @@ proc stop*(s: StorageServer) {.async.} =
 
   notice "Stopping Storage node"
 
-  var futures =
-    @[
-      s.storageNode.switch.stop(),
-      s.storageNode.stop(),
-      s.repoStore.stop(),
-      s.maintenance.stop(),
-    ]
+  var futures = @[
+    s.storageNode.switch.stop(),
+    s.storageNode.stop(),
+    s.repoStore.stop(),
+    s.maintenance.stop(),
+  ]
 
   if s.restServer != nil:
     futures.add(s.restServer.stop())

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -96,12 +96,13 @@ proc stop*(s: StorageServer) {.async.} =
 
   notice "Stopping Storage node"
 
-  var futures = @[
-    s.storageNode.switch.stop(),
-    s.storageNode.stop(),
-    s.repoStore.stop(),
-    s.maintenance.stop(),
-  ]
+  var futures =
+    @[
+      s.storageNode.switch.stop(),
+      s.storageNode.stop(),
+      s.repoStore.stop(),
+      s.maintenance.stop(),
+    ]
 
   if s.restServer != nil:
     futures.add(s.restServer.stop())

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -131,6 +131,17 @@ proc close*(s: StorageServer) {.async.} =
     error "Failed to close Storage node", failures = res.failure.len
     raiseAssert "Failed to close Storage node"
 
+  proc noOutput(logLevel: LogLevel, msg: LogOutputStr) =
+    discard
+
+  # If a log file was assigned, clear the `fileFlush` proc to ensure a clean
+  # state for future restarts.
+  # Without this manual cleanup, the old writer remains active in the global stream.
+  # When `setupLogging` is called again during a restart, the GC might trigger
+  # after the new context is created, destroying the newly assigned writer and
+  # leaving it silently capturing a `None` value. This results in missing log files.
+  defaultChroniclesStream.outputs[2].writer = noOutput
+
 proc shutdown*(server: StorageServer) {.async.} =
   await server.stop()
   await server.close()


### PR DESCRIPTION
This PR fixes an issue where log files are empty or incomplete when starting and stopping the storage node consecutively (which happens during testing).

Here is the scenario: 

1. The first test creates a storage context. It starts the node and runs the test successfully.
1. The node is stopped and the context is destroyed. However, the Chronicles output writer is not cleaned up.
1. The second test creates a new context. A new Chronicles output writer is created and assigned to the global array, replacing the old one.
1. Because the old writer is finally replaced in step 3, the GC cleans it up. Unfortunately, this GC cleanup process happens after the new writer is assigned. It ends up freeing the newly assigned writer. As a result, the new writer silently captures a None value, meaning no logs will be written for the second test. 

See [this comment](https://github.com/logos-storage/logos-storage-nim/pull/1413#issuecomment-4182247037) for more context.

This PR fixes that by cleaning the Chronicles output writer in the node `close` function.