### PR TITLE
fix: nph build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ build-nph:
 ifeq ("$(wildcard $(NPH))","")
 	cd vendor/nph && \
 	nimble setup -l && \
-	nimble build && \
+	nimble build -d:disable_libbacktrace && \
 	mv ./nph ../../$(shell dirname $(NPH)) && \
 	echo "nph utility is available at " $(NPH)
 endif


### PR DESCRIPTION
 `make build-nph` fails with Nim 2.2.4 on Linux: 
 
 ```
 ⬢ [arnaud@toolbx logos-storage-nim]$ make build-nph
   Warning: Using project local deps mode
   Warning: The compiler package has been renamed to nim
     Info:  "nimble.paths" is updated.
     Info:  "config.nims" is already set up.
   Warning: Using project local deps mode
   Warning: The compiler package has been renamed to nim
   Building nph/nph using c backend
      Info: compiling nim package using /home/arnaud/.nimble/bin/nim
 Nim Output /home/arnaud/Work/logos/logos-storage-nim/vendor/nph/config.nims(1, 2) Error: cannot open file: ""
       Tip: 30 messages have been suppressed, use --verbose to show them.
nimble.nim(415)          buildFromDir

    Error:  Build failed for the package: nph
make: *** [Makefile:217: build-nph] Error 1
⬢ [arnaud@toolbx logos-storage-nim]$ 
 ```
 
 The fix is to pass `-d:disable_libbacktrace` to `nimble build`. 