### PR TITLE
chore: update nim 2.2.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v2.2.8
+  nim_version: v2.2.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 # If NIM_COMMIT is set to "nimbusbuild", this will use the
 # version pinned by nimbus-build-system.
-PINNED_NIM_VERSION := v2.2.8
+PINNED_NIM_VERSION := v2.2.10
 
 ifeq ($(NIM_COMMIT),)
 NIM_COMMIT := $(PINNED_NIM_VERSION)

--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -8,7 +8,7 @@
 {.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
-import std/[options, locks, atomics]
+import std/[locks, atomics]
 import chronicles
 import chronos
 import chronos/threadsync
@@ -152,7 +152,7 @@ proc runStorage(ctx: ptr StorageContext) {.async: (raises: []).} =
     # synchronously until the first await
     asyncSpawn (
       proc() {.async.} =
-        await sleepAsync(0)
+        await sleepAsync(0.milliseconds)
         await StorageThreadRequest.process(request, addr storage)
     )()
 

--- a/library/storage_thread_requests/requests/node_debug_request.nim
+++ b/library/storage_thread_requests/requests/node_debug_request.nim
@@ -52,15 +52,14 @@ proc getDebug(
   let node = storage[].node
   let table = RestRoutingTable.init(node.discovery.protocol.routingTable)
 
-  let json =
-    %*{
-      "id": $node.switch.peerInfo.peerId,
-      "addrs": node.switch.peerInfo.addrs.mapIt($it),
-      "spr":
-        if node.discovery.dhtRecord.isSome: node.discovery.dhtRecord.get.toURI else: "",
-      "announceAddresses": node.discovery.announceAddrs,
-      "table": table,
-    }
+  let json = %*{
+    "id": $node.switch.peerInfo.peerId,
+    "addrs": node.switch.peerInfo.addrs.mapIt($it),
+    "spr":
+      if node.discovery.dhtRecord.isSome: node.discovery.dhtRecord.get.toURI else: "",
+    "announceAddresses": node.discovery.announceAddrs,
+    "table": table,
+  }
 
   return ok($json)
 

--- a/library/storage_thread_requests/requests/node_download_request.nim
+++ b/library/storage_thread_requests/requests/node_download_request.nim
@@ -15,13 +15,11 @@
 ## the onChunk handler for each chunk and / or writing to a file if filepath is set.
 ##    - CANCEL: cancels the download session
 
-import std/[options, streams]
 import chronos
 import chronicles
 import libp2p/stream/[lpstream]
 import serde/json as serde
 import ../../alloc
-import ../../../storage/units
 import ../../../storage/storagetypes
 
 from ../../../storage/storage import StorageServer, node
@@ -185,7 +183,7 @@ proc streamData(
     while not stream.atEof:
       ## Yield immediately to the event loop
       ## It gives a chance to cancel request to be processed
-      await sleepAsync(0)
+      await sleepAsync(0.milliseconds)
 
       let read = await stream.readOnce(addr buf[0], buf.len)
       buf.setLen(read)
@@ -213,7 +211,7 @@ proc stream(
     local: bool,
     filepath: cstring,
     onChunk: OnChunkHandler,
-): Future[Result[string, string]] {.raises: [], async: (raises: []).} =
+): Future[Result[string, string]] {.async: (raises: []).} =
   ## Stream the file identified by cid, calling the onChunk handler for each chunk
   ## and / or writing to a file if filepath is set.
   ##
@@ -252,7 +250,7 @@ proc stream(
 
 proc cancel(
     storage: ptr StorageServer, cCid: cstring
-): Future[Result[string, string]] {.raises: [], async: (raises: []).} =
+): Future[Result[string, string]] {.async: (raises: []).} =
   ## Cancel the download session identified by cid.
   ## This operation is not supported when using the stream mode,
   ## because the worker will be busy downloading the file.
@@ -280,7 +278,7 @@ proc cancel(
 
 proc manifest(
     storage: ptr StorageServer, cCid: cstring
-): Future[Result[string, string]] {.raises: [], async: (raises: []).} =
+): Future[Result[string, string]] {.async: (raises: []).} =
   let cid = Cid.init($cCid)
   if cid.isErr:
     return err("Failed to fetch manifest: cannot parse cid: " & $cCid)

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -5,7 +5,7 @@
 
 import std/[options, json, strutils, net, os]
 import codexdht/discv5/spr
-import stew/shims/parseutils
+import std/parseutils
 import contractabi/address
 import chronos
 import chronicles

--- a/library/storage_thread_requests/requests/node_storage_request.nim
+++ b/library/storage_thread_requests/requests/node_storage_request.nim
@@ -8,10 +8,8 @@
 ## - SPACE: get the amount of space used by the local node.
 ## - EXISTS: check the existence of a cid in a node (local store).
 
-import std/[options]
 import chronos
 import chronicles
-import libp2p/stream/[lpstream]
 import serde/json as serde
 import ../../alloc
 import ../../../storage/units


### PR DESCRIPTION
This PR updates Nim to 2.2.10 and performs another round of cleanup. 

It updates DHT to 0.6.2 to fix a crash issue when logging.