### PR TITLE
fix: Merkle tree proof length check

### DIFF
--- a/storage/merkletree/merkletree.nim
+++ b/storage/merkletree/merkletree.nim
@@ -65,7 +65,7 @@ func verify*(self: StorageMerkleProof, leaf: MultiHash, root: MultiHash): ?!bool
   if self.mcodec != root.mcodec or self.mcodec != leaf.mcodec:
     return failure "Hash codec mismatch"
 
-  if rootBytes.len != root.size and leafBytes.len != leaf.size:
+  if rootBytes.len != root.size or leafBytes.len != leaf.size:
     return failure "Invalid hash length"
 
   self.verify(leafBytes, rootBytes)


### PR DESCRIPTION
Fixes: https://github.com/status-im/audit-reports/issues/68

This clearly has to be an `or`: if either one of the conditions fail, the check must fail.