### PR TITLE
chore: update nimbus build system

### DIFF
--- a/nix/checksums.nix
+++ b/nix/checksums.nix
@@ -8,5 +8,5 @@ in pkgs.fetchFromGitHub {
   repo = "checksums";
   rev = tools.findKeyValue "^ +ChecksumsStableCommit = \"([a-f0-9]+)\".*$" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
-  hash = "sha256-JZhWqn4SrAgNw/HLzBK0rrj3WzvJ3Tv1nuDMn83KoYY=";
+  hash = "sha256-xC11sD13OTMMUY4F5CrF1XxKSigLtIPt2XQCcQOFNdM=";
 }

--- a/nix/csources.nix
+++ b/nix/csources.nix
@@ -5,8 +5,8 @@ let
   sourceFile = ../vendor/nimbus-build-system/vendor/Nim/config/build_config.txt;
 in pkgs.fetchFromGitHub {
   owner = "nim-lang";
-  repo = "csources_v2";
+  repo = "csources_v3";
   rev = tools.findKeyValue "^nim_csourcesHash=([a-f0-9]+)$" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
-  hash = "sha256-UCLtoxOcGYjBdvHx7A47x6FjLMi6VZqpSs65MN7fpBs=";
+  hash = "sha256-pTcm2y+HDOuTol8DyoJMOMHsUA6QrgwGdfcOu1NX4PU=";
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -68,6 +68,9 @@ in stdenv.mkDerivation rec {
     export XDG_CACHE_HOME=$TMPDIR
     # Force build of Nimble from dist/nimble source.
     export NIMBLE_COMMIT=""
+    # build_nim.sh only skips its "rm -rf dist/checksums" hack when it sees the
+    # standard sandbox build top; force it so it keeps our offline checksums copy.
+    export NIX_BUILD_TOP=/build
     patchShebangs . vendor/nimbus-build-system > /dev/null
     make nimbus-build-system-paths
   '';

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -63,15 +63,11 @@ in stdenv.mkDerivation rec {
     "QUICK_AND_DIRTY_NIMBLE=${if quickAndDirty then "1" else "0"}"
   ];
 
-  # FIXME: Remove once permanent fix is applied to NBS:
-  patchPhase = ''
-    substituteInPlace vendor/nimbus-build-system/scripts/build_nim.sh \
-      --replace-fail '"''${NIX_BUILD_TOP}" != "/build"' '-z $${NIX_BUILD_TOP}'
-  '';
-
   configurePhase = ''
     # Avoid Nim cache permission errors.
     export XDG_CACHE_HOME=$TMPDIR
+    # Force build of Nimble from dist/nimble source.
+    export NIMBLE_COMMIT=""
     patchShebangs . vendor/nimbus-build-system > /dev/null
     make nimbus-build-system-paths
   '';

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -81,8 +81,8 @@ in stdenv.mkDerivation rec {
     mkdir dist
     cp -r ${callPackage ./nimble.nix {}}    dist/nimble
     cp -r ${callPackage ./checksums.nix {}} dist/checksums
-    cp -r ${callPackage ./csources.nix {}}  csources_v2
-    chmod 777 -R dist/nimble csources_v2
+    cp -r ${callPackage ./csources.nix {}}  csources_v3
+    chmod 777 -R dist/nimble csources_v3
     popd
   '';
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -68,9 +68,6 @@ in stdenv.mkDerivation rec {
     export XDG_CACHE_HOME=$TMPDIR
     # Force build of Nimble from dist/nimble source.
     export NIMBLE_COMMIT=""
-    # build_nim.sh only skips its "rm -rf dist/checksums" hack when it sees the
-    # standard sandbox build top; force it so it keeps our offline checksums copy.
-    export NIX_BUILD_TOP=/build
     patchShebangs . vendor/nimbus-build-system > /dev/null
     make nimbus-build-system-paths
   '';

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -2,7 +2,7 @@
 
 let
   tools = pkgs.callPackage ./tools.nix {};
-  nbsVersion = tools.findKeyValue "^[[:space:]]+NIMBLE_COMMIT='([a-f0-9]+)'.*$" ../vendor/nimbus-build-system/scripts/build_nim.sh;
+  nbsVersion = tools.findKeyValue "^[[:space:]]+: .*NIMBLE_COMMIT:=([a-f0-9]+).*$" ../vendor/nimbus-build-system/scripts/build_nim.sh;
   nimVersion = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
   sourceFile = ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
 in pkgs.fetchFromGitHub {

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -2,12 +2,14 @@
 
 let
   tools = pkgs.callPackage ./tools.nix {};
+  nbsVersion = tools.findKeyValue "^[[:space:]]+NIMBLE_COMMIT='([a-f0-9]+)'.*$" ../vendor/nimbus-build-system/scripts/build_nim.sh;
+  nimVersion = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
   sourceFile = ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
 in pkgs.fetchFromGitHub {
   owner = "nim-lang";
   repo = "nimble";
   fetchSubmodules = true;
-  rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" sourceFile;
+  rev = if nbsVersion != null then nbsVersion else nimVersion;
   # WARNING: Requires manual updates when Nim compiler version changes.
-  hash = "sha256-wgzFhModFkwB8st8F5vSkua7dITGGC2cjoDvgkRVZMs=";
+  hash = "sha256-v0RhIx6ithFJqH6ThKpyvC0JB3CBCevahhCossC+deA=";
 }

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -2,7 +2,7 @@
 
 let
   tools = pkgs.callPackage ./tools.nix {};
-  nbsVersion = tools.findKeyValue "^[[:space:]]+: .*NIMBLE_COMMIT:=([a-f0-9]+).*$" ../vendor/nimbus-build-system/scripts/build_nim.sh;
+  nbsVersion = tools.findKeyValue "^[[:space:]]+NIMBLE_COMMIT='([a-f0-9]+)'.*$" ../vendor/nimbus-build-system/scripts/build_nim.sh;
   nimVersion = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
   sourceFile = ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
 in pkgs.fetchFromGitHub {


### PR DESCRIPTION
For the NAT Traversal PR, it is required to update nimbus build system which involves some changes in Nix configuration.