### PR TITLE
chore: remove unused cache and make discovery IP limits configurable

### DIFF
--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -272,15 +272,22 @@ type
       name: "block-retries"
     .}: int
 
-    cacheSize* {.
+    discoveryTableIpLimit* {.
+      desc: "Maximum number of nodes with the same IP in the discovery routing table",
+      defaultValue: 10'u,
+      defaultValueDesc: "10",
+      name: "discovery-table-ip-limit",
+      hidden
+    .}: uint
+
+    discoveryBucketIpLimit* {.
       desc:
-        "The size of the block cache, 0 disables the cache - " &
-        "might help on slow hardrives",
-      defaultValue: 0,
-      defaultValueDesc: "0",
-      name: "cache-size",
-      abbr: "c"
-    .}: NBytes
+        "Maximum number of nodes with the same IP per bucket in the discovery routing table",
+      defaultValue: 2'u,
+      defaultValueDesc: "2",
+      name: "discovery-bucket-ip-limit",
+      hidden
+    .}: uint
 
     logFile* {.
       desc: "Logs to file", defaultValue: string.none, name: "log-file", hidden

--- a/storage/discovery.nim
+++ b/storage/discovery.nim
@@ -240,6 +240,7 @@ proc new*(
     announceAddrs: openArray[MultiAddress],
     bootstrapNodes: openArray[SignedPeerRecord] = [],
     store: Datastore = SQLiteDatastore.new(Memory).expect("Should not fail!"),
+    tableIpLimits: TableIpLimits = DefaultTableIpLimits,
 ): Discovery =
   ## Create a new Discovery node instance for the given key and datastore
   ##
@@ -250,14 +251,8 @@ proc new*(
 
   self.updateAnnounceRecord(announceAddrs)
 
-  # --------------------------------------------------------------------------
-  # FIXME disable IP limits temporarily so we can run our workshop. Re-enable
-  #   and figure out proper solution.
-  let discoveryConfig = DiscoveryConfig(
-    tableIpLimits: TableIpLimits(tableIpLimit: high(uint), bucketIpLimit: high(uint)),
-    bitsPerHop: DefaultBitsPerHop,
-  )
-  # --------------------------------------------------------------------------
+  let discoveryConfig =
+    DiscoveryConfig(tableIpLimits: tableIpLimits, bitsPerHop: DefaultBitsPerHop)
 
   self.protocol = newProtocol(
     key,

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -184,9 +184,7 @@ proc new*(
     .withTcpTransport({ServerFlags.ReuseAddr, ServerFlags.TcpNoDelay})
     .build()
 
-  var
-    cache: CacheStore = nil
-    taskPool: Taskpool
+  var taskPool: Taskpool
 
   try:
     if config.numThreads == ThreadCount(0):
@@ -196,10 +194,6 @@ proc new*(
     info "Threadpool started", numThreads = taskPool.numThreads
   except CatchableError as exc:
     raiseAssert("Failure in taskPool initialization:" & exc.msg)
-
-  if config.cacheSize > 0'nb:
-    cache = CacheStore.new(cacheSize = config.cacheSize)
-    ## Is unused?
 
   let discoveryDir = config.dataDir / StorageDhtNamespace
 

--- a/tests/storage/helpers/nodeutils.nim
+++ b/tests/storage/helpers/nodeutils.nim
@@ -5,6 +5,7 @@ import pkg/taskpools
 import pkg/libp2p
 import pkg/libp2p/errors
 
+import pkg/codexdht/discv5/routing_table
 import pkg/storage/discovery
 import pkg/storage/stores
 import pkg/storage/blocktype as bt
@@ -180,6 +181,8 @@ proc generateNodes*(
                 bindPort = bindPort.Port,
                 store = blockDiscoveryStore,
                 bootstrapNodes = bootstrapNodes,
+                tableIpLimits =
+                  TableIpLimits(tableIpLimit: high(uint), bucketIpLimit: high(uint)),
               )
             else:
               nullDiscovery()
@@ -189,8 +192,12 @@ proc generateNodes*(
       else:
         let
           store = CacheStore.new(blocks.mapIt(it))
-          discovery =
-            Discovery.new(switch.peerInfo.privateKey, announceAddrs = @[listenAddr])
+          discovery = Discovery.new(
+            switch.peerInfo.privateKey,
+            announceAddrs = @[listenAddr],
+            tableIpLimits =
+              TableIpLimits(tableIpLimit: high(uint), bucketIpLimit: high(uint)),
+          )
         (store.BlockStore, newSeq[TempLevelDb](), discovery)
 
     let


### PR DESCRIPTION
- Remove unused CacheStore instance and cacheSize CLI option                                                          
- Add hidden CLI options `--discovery-table-ip-limit` (default: 10) and `--discovery-bucket-ip-limit` (default: 2) to configure discv5 routing table IP limits, replacing the hardcoded `high(uint)` that disabled all protection     