### PR TITLE
chore: include cancelled futures in failures

### DIFF
--- a/storage/errors.nim
+++ b/storage/errors.nim
@@ -86,10 +86,10 @@ proc allFinishedFailed*[T](
   var res: FinishedFailed[T] = (@[], @[])
   await allFutures(futs)
   for f in futs:
-    if f.failed:
-      res.failure.add f
-    else:
+    if f.completed:
       res.success.add f
+    else:
+      res.failure.add f
 
   return res
 


### PR DESCRIPTION
`allFinishedFailed` used `f.failed`, which is false for cancelled futures, so they were counted as successes. A cancelled future never belongs in `success`.

Switch to `f.completed`: cancelled futures now land in `failure`.

Example: in `updateExpiry`, a cancelled `ensureExpiry` future meant the block's expiry was not updated, yet the proc returned success.

