### PR TITLE
refactor(release): `emptyDir` volumes are now used over PVCs, so no need to clean up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,26 +388,6 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: terraform destroy -auto-approve
 
-      - name: Delete orphaned GCE disks
-        if: always() && steps.tf-apply.conclusion != 'skipped'
-        env:
-          GCP_PROJECT: ${{ vars.RELEASE_TESTS_GCP_PROJECT }}
-        run: |
-          # Safety net: delete any pvc-* disks the CSI driver did not release before
-          # the cluster was destroyed. Runs after terraform destroy so disks are
-          # guaranteed detached (GCE rejects deletes on attached disks). The
-          # releaseTestsDiskCleaner IAM role is granted out-of-band (not via Terraform)
-          # so it persists across cluster lifecycles — see CLAUDE.md for details.
-          gcloud compute disks list \
-            --project="$GCP_PROJECT" \
-            --filter="name~^pvc-" \
-            --format="value(name,zone.basename())" \
-          | while IFS=$'\t' read -r name zone; do
-              [[ -n "$name" && -n "$zone" ]] || continue
-              gcloud compute disks delete "$name" --zone="$zone" \
-                --project="$GCP_PROJECT" --quiet || true
-            done
-
       - name: Release Terraform state lock
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,16 @@ on:
         default: 'master'
         type: string
 
+concurrency: 
+  # Prenvent concurrent release runs. This happens, eg, in a
+  # double-dispatch (clicking "Run workflow" multiple times in a row) or if
+  # multiple commits are pushed in quick succession to master (eg, a bugfix
+  # right after a release commit).
+  # All runs target the same shared GCP cluster/Terraform state, so serialize 
+  # them instead of racing for the state lock. 
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
   nim_version: pinned


### PR DESCRIPTION
PVCs were not needed for the release dist tests. The PVCs were dropped in exchange for ephemeral `emptyDir` volumes that are tied to the lifetime of the pods. As such, we no longer need to clean up orphaned PVCs at the end of a Release workflow run.