### PR TITLE
fix: `allFinishedFailed` -> `allDone` to retain cancellations

### DIFF
--- a/storage/errors.nim
+++ b/storage/errors.nim
@@ -51,6 +51,11 @@ type
 
   FinishedFailed*[T] = tuple[success: seq[Future[T]], failure: seq[Future[T]]]
 
+  FinishedFutures*[T] = tuple[
+    completed: seq[Future[T]],
+    failed: seq[Future[T]],
+    cancelled: seq[Future[T]]]
+
 proc wantBlocksError*(kind: WantBlocksErrorKind, msg: string): ref WantBlocksError =
   (ref WantBlocksError)(kind: kind, msg: msg)
 
@@ -115,3 +120,28 @@ proc allFinishedValues*[T](
       if b.finished:
         b.value
   return success values
+
+
+proc allDone*[T](futs: auto): Future[FinishedFutures[T]] {.async: (raises: [CancelledError]).} =
+  ## Returns a future which will complete only when all futures in ``futs``
+  ## will be completed, failed or cancelled.
+  ##
+  ## Returned FinishedFutures will hold all the Future[T] objects passed to
+  ## ``allDone``, grouped by their end state, with the order preserved.
+  ##
+  ## If the argument is empty, the returned future COMPLETES immediately.
+  ##
+  ## On cancel all the awaited futures ``futs`` WILL NOT BE cancelled.
+  ##
+  ## This is different from nim-chronos' ``allFinished``, in that the completed
+  ## futures are grouped by their end state.
+  await allFutures(futs)
+  var res: FinishedFutures[T] = (@[], @[], @[])
+  for f in futs:
+    if f.completed:
+      res.completed.add f
+    elif f.cancelled:
+      res.cancelled.add f
+    else:
+      res.failed.add f
+  return res

--- a/storage/errors.nim
+++ b/storage/errors.nim
@@ -139,6 +139,12 @@ proc allDone*[T](futs: auto): Future[FinishedFutures[T]] {.async: (raises: [Canc
   var res: FinishedFutures[T] = (@[], @[], @[])
   for f in futs:
     if f.completed:
+      when T is Result:
+        # count successfully completed Future containing Results with errors as
+        # failed
+        if f.value.isErr:
+          res.failed.add f
+          continue
       res.completed.add f
     elif f.cancelled:
       res.cancelled.add f

--- a/storage/errors.nim
+++ b/storage/errors.nim
@@ -51,10 +51,8 @@ type
 
   FinishedFailed*[T] = tuple[success: seq[Future[T]], failure: seq[Future[T]]]
 
-  FinishedFutures*[T] = tuple[
-    completed: seq[Future[T]],
-    failed: seq[Future[T]],
-    cancelled: seq[Future[T]]]
+  FinishedFutures*[T] =
+    tuple[completed: seq[Future[T]], failed: seq[Future[T]], cancelled: seq[Future[T]]]
 
 proc wantBlocksError*(kind: WantBlocksErrorKind, msg: string): ref WantBlocksError =
   (ref WantBlocksError)(kind: kind, msg: msg)
@@ -121,8 +119,9 @@ proc allFinishedValues*[T](
         b.value
   return success values
 
-
-proc allDone*[T](futs: auto): Future[FinishedFutures[T]] {.async: (raises: [CancelledError]).} =
+proc allDone*[T](
+    futs: auto
+): Future[FinishedFutures[T]] {.async: (raises: [CancelledError]).} =
   ## Returns a future which will complete only when all futures in ``futs``
   ## will be completed, failed or cancelled.
   ##
@@ -137,6 +136,7 @@ proc allDone*[T](futs: auto): Future[FinishedFutures[T]] {.async: (raises: [Canc
   ## futures are grouped by their end state.
   await allFutures(futs)
   var res: FinishedFutures[T] = (@[], @[], @[])
+
   for f in futs:
     if f.completed:
       when T is Result:
@@ -150,4 +150,5 @@ proc allDone*[T](futs: auto): Future[FinishedFutures[T]] {.async: (raises: [Canc
       res.cancelled.add f
     else:
       res.failed.add f
+
   return res

--- a/storage/node.nim
+++ b/storage/node.nim
@@ -120,10 +120,15 @@ proc updateExpiry*(
         self.networkStore.localStore.ensureExpiry(manifest.treeCid, it, expiry)
       )
 
-    let res = await allFinishedFailed[?!void](ensuringFutures)
-    if res.failure.len > 0:
-      trace "Some blocks failed to update expiry", len = res.failure.len
-      return failure("Some blocks failed to update expiry (" & $res.failure.len & " )")
+    let res = await allDone[?!void](ensuringFutures)
+    let failed = res.completed.countIt(it.value.isErr) + res.failed.len
+    if failed > 0:
+      trace "Some blocks failed to update expiry", len = failed
+      return failure("Some blocks failed to update expiry (" & $failed & " )")
+    if res.cancelled.len > 0:
+      trace "Block expiry update was cancelled in some blocks",
+        len = res.cancelled.len
+      raise newException(CancelledError, "Block expiry update was cancelled in some blocks")
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:

--- a/storage/node.nim
+++ b/storage/node.nim
@@ -125,9 +125,9 @@ proc updateExpiry*(
       trace "Some blocks failed to update expiry", len = res.failed.len
       return failure("Some blocks failed to update expiry (" & $res.failed.len & " )")
     if res.cancelled.len > 0:
-      trace "Block expiry update was cancelled in some blocks",
-        len = res.cancelled.len
-      raise newException(CancelledError, "Block expiry update was cancelled in some blocks")
+      trace "Block expiry update was cancelled in some blocks", len = res.cancelled.len
+      raise
+        newException(CancelledError, "Block expiry update was cancelled in some blocks")
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:

--- a/storage/node.nim
+++ b/storage/node.nim
@@ -121,10 +121,9 @@ proc updateExpiry*(
       )
 
     let res = await allDone[?!void](ensuringFutures)
-    let failed = res.completed.countIt(it.value.isErr) + res.failed.len
-    if failed > 0:
-      trace "Some blocks failed to update expiry", len = failed
-      return failure("Some blocks failed to update expiry (" & $failed & " )")
+    if res.failed.len > 0:
+      trace "Some blocks failed to update expiry", len = res.failed.len
+      return failure("Some blocks failed to update expiry (" & $res.failed.len & " )")
     if res.cancelled.len > 0:
       trace "Block expiry update was cancelled in some blocks",
         len = res.cancelled.len

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -117,29 +117,33 @@ proc stop*(s: StorageServer) {.async.} =
   if s.restServer != nil:
     futures.add(s.restServer.stop())
 
-  let res = await noCancel allFinishedFailed[void](futures)
+  let res = await noCancel allDone[void](futures)
 
   s.isStarted = false
 
-  if res.failure.len > 0:
-    error "Failed to stop Storage node", failures = res.failure.len
+  if res.failed.len > 0:
+    error "Failed to stop Storage node", failures = res.failed.len
     raise newException(
       StorageError,
-      "Failed to stop Storage node: " & res.failure.mapIt(it.error.msg).join(", "),
+      "Failed to stop Storage node: " & res.failed.mapIt(it.error.msg).join(", "),
+    )
+  if res.cancelled.len > 0:
+    warn "Storage node stop was cancelled due to child stop routine(s) being cancelled, child routines cancelled: ",
+      cancellations = res.cancelled.len
+    raise newException(
+      CancelledError,
+      "Storage node stop was cancelled due to child stop routine(s) being cancelled, child routines cancelled: " &
+        $res.cancelled.len,
     )
 
 proc close*(s: StorageServer) {.async.} =
   var futures =
     @[s.storageNode.close(), s.repoStore.close(), s.storageNode.discovery.close()]
 
-  let res = await noCancel allFinishedFailed[void](futures)
+  let res = await noCancel allDone[void](futures)
 
   if not s.taskpool.isNil:
-    try:
-      s.taskpool.shutdown()
-    except Exception as exc:
-      error "Failed to stop the taskpool", failures = res.failure.len
-      raise newException(StorageError, "Failure in taskpool shutdown: " & exc.msg)
+    s.taskpool.shutdown()
 
   when defaultChroniclesStream.outputs.type.arity >= 3:
     proc noOutput(logLevel: LogLevel, msg: LogOutputStr) =
@@ -151,11 +155,19 @@ proc close*(s: StorageServer) {.async.} =
     if error =? closeFile(s.logFile.get()).errorOption:
       error "Failed to close log file", errorCode = $error
 
-  if res.failure.len > 0:
-    error "Failed to close Storage node", failures = res.failure.len
+  if res.failed.len > 0:
+    error "Failed to close Storage node", failures = res.failed.len
     raise newException(
       StorageError,
-      "Failed to close Storage node: " & res.failure.mapIt(it.error.msg).join(", "),
+      "Failed to close Storage node: " & res.failed.mapIt(it.error.msg).join(", "),
+    )
+  if res.cancelled.len > 0:
+    warn "Storage node close was cancelled due to child close routine(s) being cancelled, child routines cancelled: ",
+      cancellations = res.cancelled.len
+    raise newException(
+      CancelledError,
+      "Storage node close was cancelled due to child close routine(s) being cancelled, child routines cancelled: " &
+        $res.cancelled.len,
     )
 
 proc shutdown*(server: StorageServer) {.async.} =

--- a/tests/storage/node/testnode.nim
+++ b/tests/storage/node/testnode.nim
@@ -248,5 +248,3 @@ asyncchecksuite "Test Node - Basic":
       expiry = SecondsSince1970(9999999999)
     let res = await node.updateExpiry(manifestBlk.cid, expiry)
     check res.isErr
-
-

--- a/tests/storage/node/testnode.nim
+++ b/tests/storage/node/testnode.nim
@@ -233,3 +233,20 @@ asyncchecksuite "Test Node - Basic":
     let randomBlock = bt.Block.new("Random block".toBytes).tryGet()
 
     check (await node.hasLocalBlock(randomBlock.cid)) == false
+
+  test "updateExpiry succeeds when all blocks have metadata":
+    let
+      md = await storeDataGetManifest(localStore, chunker)
+      expiry = SecondsSince1970(9999999999)
+    let res = await node.updateExpiry(md.manifestCid, expiry)
+    check res.isOk
+
+  test "updateExpiry returns failure when block metadata is missing":
+    let
+      manifest = Manifest.example
+      manifestBlk = (await node.storeManifest(manifest)).tryGet()
+      expiry = SecondsSince1970(9999999999)
+    let res = await node.updateExpiry(manifestBlk.cid, expiry)
+    check res.isErr
+
+

--- a/tests/storage/testerrors.nim
+++ b/tests/storage/testerrors.nim
@@ -48,9 +48,11 @@ asyncchecksuite "allDone":
 
   test "futures are grouped by their end state":
     let
-      completed = Future[void].Raising([CancelledError, CatchableError]).init("completed")
+      completed =
+        Future[void].Raising([CancelledError, CatchableError]).init("completed")
       failed = Future[void].Raising([CancelledError, CatchableError]).init("failed")
-      cancelled = Future[void].Raising([CancelledError, CatchableError]).init("cancelled")
+      cancelled =
+        Future[void].Raising([CancelledError, CatchableError]).init("cancelled")
     completed.complete()
     failed.fail(newException(CatchableError, "e"))
     await cancelled.cancelAndWait()

--- a/tests/storage/testerrors.nim
+++ b/tests/storage/testerrors.nim
@@ -1,0 +1,89 @@
+import pkg/chronos
+
+import pkg/storage/errors
+
+import ../asynctest
+import ../checktest
+
+asyncchecksuite "allDone":
+  test "empty sequence completes immediately with all groups empty":
+    let futs = newSeq[Future[void]]()
+    let res = await allDone[void](futs)
+    check res.completed.len == 0
+    check res.failed.len == 0
+    check res.cancelled.len == 0
+
+  test "all completed futures go in the completed group":
+    let
+      fut1 = Future[void].Raising([CancelledError]).init("f1")
+      fut2 = Future[void].Raising([CancelledError]).init("f2")
+    fut1.complete()
+    fut2.complete()
+    let res = await allDone[void](@[fut1, fut2])
+    check res.completed.len == 2
+    check res.failed.len == 0
+    check res.cancelled.len == 0
+
+  test "all failed futures go in the failed group":
+    let
+      fut1 = Future[void].Raising([CancelledError, CatchableError]).init("f1")
+      fut2 = Future[void].Raising([CancelledError, CatchableError]).init("f2")
+    fut1.fail(newException(CatchableError, "e1"))
+    fut2.fail(newException(CatchableError, "e2"))
+    let res = await allDone[void](@[fut1, fut2])
+    check res.completed.len == 0
+    check res.failed.len == 2
+    check res.cancelled.len == 0
+
+  test "all cancelled futures go in the cancelled group":
+    let
+      fut1 = Future[void].Raising([CancelledError]).init("f1")
+      fut2 = Future[void].Raising([CancelledError]).init("f2")
+    await fut1.cancelAndWait()
+    await fut2.cancelAndWait()
+    let res = await allDone[void](@[fut1, fut2])
+    check res.completed.len == 0
+    check res.failed.len == 0
+    check res.cancelled.len == 2
+
+  test "futures are grouped by their end state":
+    let
+      completed = Future[void].Raising([CancelledError, CatchableError]).init("completed")
+      failed = Future[void].Raising([CancelledError, CatchableError]).init("failed")
+      cancelled = Future[void].Raising([CancelledError, CatchableError]).init("cancelled")
+    completed.complete()
+    failed.fail(newException(CatchableError, "e"))
+    await cancelled.cancelAndWait()
+    let res = await allDone[void](@[completed, failed, cancelled])
+    check res.completed.len == 1
+    check res.failed.len == 1
+    check res.cancelled.len == 1
+    check res.completed[0] == completed
+    check res.failed[0] == failed
+    check res.cancelled[0] == cancelled
+
+  test "order within each group matches the original input order":
+    let
+      fut1 = Future[void].Raising([CancelledError]).init("f1")
+      fut2 = Future[void].Raising([CancelledError]).init("f2")
+      fut3 = Future[void].Raising([CancelledError]).init("f3")
+    fut1.complete()
+    fut2.complete()
+    fut3.complete()
+    let res = await allDone[void](@[fut1, fut2, fut3])
+    check res.completed.len == 3
+    check res.completed[0] == fut1
+    check res.completed[1] == fut2
+    check res.completed[2] == fut3
+
+  test "cancelling allDone does not cancel the awaited futures":
+    let
+      fut1 = Future[void].Raising([CancelledError]).init("f1")
+      fut2 = Future[void].Raising([CancelledError]).init("f2")
+    let doneFut = allDone[void](@[fut1, fut2])
+    await doneFut.cancelAndWait()
+    check doneFut.cancelled
+    check not fut1.cancelled
+    check not fut2.cancelled
+    fut1.complete()
+    fut2.complete()

--- a/tests/storage/testerrors.nim
+++ b/tests/storage/testerrors.nim
@@ -87,3 +87,16 @@ asyncchecksuite "allDone":
     check not fut2.cancelled
     fut1.complete()
     fut2.complete()
+
+  test "failed Result is grouped as a failed future":
+    let
+      fut1 = Future[Result[int, string]].Raising([CancelledError]).init("f1")
+      fut2 = Future[Result[int, string]].Raising([CancelledError]).init("f2")
+    fut1.complete(Result[int, string].ok(42))
+    fut2.complete(Result[int, string].err("error"))
+    let res = await allDone[Result[int, string]](@[fut1, fut2])
+    check res.completed.len == 1
+    check res.failed.len == 1
+    check res.cancelled.len == 0
+    check res.completed[0] == fut1
+    check res.failed[0] == fut2


### PR DESCRIPTION
This PR replaces the `allFinishedFailed` proc with `allDone`, exposing in the return all the futures and their final state. This allows the caller to make a decision on what to do with the resulting futures. It does not make a decision as to what a "failed" or "successful" future looks like. 

The [recent change in the `allFinishedFailed` util](https://github.com/logos-storage/logos-storage-nim/commit/85d8822704cb517df18a3817ff7fb3dcc008b222), where cancelled futures were changed from being "successes" to "failures", means that cancellations in the underlying futures went from being swallowed to exposed as a failure. 

### Higher potential impact changes
During block expiry update, if one of the block expiry updates is cancelled, the `CancelledError` is now propagated, and `updateExpiry` will be cancelled, where previously (before 85d8822), a cancellation in an underlying future would have been swallowed. After 85d8822, this would have returned a failed result. However, raising and propagating a `CancelledError` seems more appropriate for the case, however I'd like a second opinion on it please. 

### Lower impact changes
`StorageServer.close()` and `StorageServer.stop()` both called `allFuturesFailed`. Previously (before 85d8822), this cancellation would be swallowed. After 85d8822, the cancellation would be considered "failed" and it would raise a `StorageError` exception. Now, cancellations in the underlying futures will raise a `CancelledError`.

> [!NOTE]
> `allDone` was used instead of `allFinished` to avoid clashing with nim-chronos. Happy to change it to something else if desired, eg `allFinishedFutures`.