### PR TITLE
fix(ci): scope disableMarchNative to linux amd64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,16 +104,22 @@ jobs:
           echo "storage_binary=${storage_binary}" >>$GITHUB_ENV
           echo "c_bindings_lib=${c_bindings_lib}" >>$GITHUB_ENV
 
-      - name: Build Logos Storage binary
+      - name: Compute platform Nim flags
+        id: platform-nim-flags
+        shell: bash
         run: |
-          nim_flags="${{ env.nim_flags }}"
+          platform_nim_flags=""
           # secp256k1's x86_64 inline asm can hit a GCC register-allocation
           # failure when -march=native expands against this runner's CPU, so
           # pin a fixed baseline instead. arm64/macOS don't use that asm path.
           if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.cpu }}" == "amd64" ]]; then
-            nim_flags="${nim_flags} -d:disableMarchNative"
+            platform_nim_flags="-d:disableMarchNative"
           fi
-          make NIMFLAGS="--out:${{ env.build_dir }}/${{ env.storage_binary }} ${nim_flags}"
+          echo "nim_flags=${platform_nim_flags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Logos Storage binary
+        run: |
+          make NIMFLAGS="--out:${{ env.build_dir }}/${{ env.storage_binary }} ${{ env.nim_flags }} ${{ steps.platform-nim-flags.outputs.nim_flags }}"
 
       - name: Package ${{ env.storage_binary_base }} Linux (compress and preserve perms)
         if: matrix.os == 'linux'
@@ -160,20 +166,20 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           make -j${ncpu} update
-          make -j${ncpu} NIMFLAGS="-d:disableMarchNative" libstorage
+          make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Build ${{ env.c_bindings_lib_base }} (MacOS)
         if: matrix.os == 'macos'
         run: |
           make -j${ncpu} update
-          STORAGE_LIB_PARAMS="--passL:\"-Wl,-install_name,@rpath/${{ env.c_bindings_lib_base }}.dylib\"" make -j${ncpu} NIMFLAGS="-d:disableMarchNative" libstorage
+          STORAGE_LIB_PARAMS="--passL:\"-Wl,-install_name,@rpath/${{ env.c_bindings_lib_base }}.dylib\"" make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Build ${{ env.c_bindings_lib_base }} (Windows)
         if: matrix.os == 'windows'
         shell: msys2 {0}
         run: |
           make -j${ncpu} update
-          make -j${ncpu} NIMFLAGS="-d:disableMarchNative" libstorage
+          make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Package ${{ env.c_bindings_lib_base }} Linux
         if: matrix.os == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build Logos Storage binary
         run: |
-          make NIMFLAGS="--out:${{ env.build_dir }}/${{ env.storage_binary }} ${{ env.nim_flags }} ${{ steps.platform-nim-flags.outputs.nim_flags }}"
+          make NIMFLAGS="${NIMFLAGS} --out:${{ env.build_dir }}/${{ env.storage_binary }} ${{ env.nim_flags }} ${{ steps.platform-nim-flags.outputs.nim_flags }}"
 
       - name: Package ${{ env.storage_binary_base }} Linux (compress and preserve perms)
         if: matrix.os == 'linux'
@@ -166,20 +166,20 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           make -j${ncpu} update
-          make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
+          make -j${ncpu} NIMFLAGS="${NIMFLAGS} ${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Build ${{ env.c_bindings_lib_base }} (MacOS)
         if: matrix.os == 'macos'
         run: |
           make -j${ncpu} update
-          STORAGE_LIB_PARAMS="--passL:\"-Wl,-install_name,@rpath/${{ env.c_bindings_lib_base }}.dylib\"" make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
+          STORAGE_LIB_PARAMS="--passL:\"-Wl,-install_name,@rpath/${{ env.c_bindings_lib_base }}.dylib\"" make -j${ncpu} NIMFLAGS="${NIMFLAGS} ${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Build ${{ env.c_bindings_lib_base }} (Windows)
         if: matrix.os == 'windows'
         shell: msys2 {0}
         run: |
           make -j${ncpu} update
-          make -j${ncpu} NIMFLAGS="${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
+          make -j${ncpu} NIMFLAGS="${NIMFLAGS} ${{ steps.platform-nim-flags.outputs.nim_flags }}" libstorage
 
       - name: Package ${{ env.c_bindings_lib_base }} Linux
         if: matrix.os == 'linux'


### PR DESCRIPTION
## Summary

Refines the release workflow so `-d:disableMarchNative` is applied only where needed: Linux amd64 release builds.

## Details

The previous workflow change passed `-d:disableMarchNative` unconditionally to all `libstorage` builds, including macOS and Windows. That is broader than necessary because the observed failure is specific to secp256k1's x86_64 inline assembly when `-march=native` expands against certain Linux amd64 CPUs.

This change:
- Computes platform-specific Nim flags once via a GitHub Actions step output.
- Adds `-d:disableMarchNative` only for `matrix.os == linux` and `matrix.cpu == amd64`.
- Reuses that platform flag for both the main release binary and `libstorage`.
- Preserves `NIMFLAGS` exported by the Nimbus setup action, such as Linux stack-usage flags and macOS OpenMP-related flags.
- Keeps `${{ env.nim_flags }}` scoped to the main binary build so binary-specific flags do not leak into `libstorage`.
- Preserves the existing macOS `STORAGE_LIB_PARAMS` linker flag for `libstorage`.