### PR TITLE
fix: byte serialization of libp2p pubkey on debug endpoint

### DIFF
--- a/storage/rest/json.nim
+++ b/storage/rest/json.nim
@@ -107,7 +107,7 @@ proc init*(_: type DebugInfo, node: StorageNodeRef): DebugInfo =
   let
     peerInfo = node.switch.peerInfo
     peerId = peerInfo.peerId
-    libp2pPubKeyBytes = peerInfo.publicKey.getBytes()
+    libp2pPubKeyBytes = peerInfo.publicKey.getRawBytes()
 
   # Cause there's no canonical way to get your own key from MixProtocol
   # that I'm aware of.


### PR DESCRIPTION
In exposing the libp2p key over the debug endpoint, I copied what we had in the mixtools, which is roughly:

```nim
byteutils.toHex(libp2pPubKey.getBytes()),
```

Turns out that if you invoke this in a libp2p `PublicKey` object, it will protobuf-serialize the key, and then decoding (which expects a raw key) fails. This addresses that by calling `getRawBytes` instead.