### PR TITLE
ci: publish openapi.yaml as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,6 +424,9 @@ jobs:
     needs: [build, release-tests]
     if: needs.build.result == 'success' && needs.release-tests.result == 'success'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Set conditional env variables
         shell: bash
         run: |
@@ -454,6 +457,7 @@ jobs:
         with:
           files: |
             /tmp/release/*-*
+            openapi.yaml
           make_latest: true
 
       - name: Generate Python SDK


### PR DESCRIPTION
Attach openapi.yaml to tagged GitHub releases so external consumers (the Python SDK, docs site, third parties) have a stable per-version URL for the API spec. 