### PR TITLE
feat: simplify libstorage lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ make coverage && make show-coverage
 
 **REST API** (`storage/rest/`): HTTP API surface. See `openapi.yaml` for the full spec.
 
-**C library bindings** (`library/`): `libstorage.nim` exposes a C ABI via `storage_new / storage_start / storage_stop / storage_destroy`. All API calls are async and deliver results via a `StorageCallback`. Callbacks must be fast and non-blocking (they run on the worker thread).
+**C library bindings** (`library/`): `libstorage.nim` exposes a C ABI via `storage_new / storage_start / storage_shutdown`. All API calls are async and deliver results via a `StorageCallback`. Callbacks must be fast and non-blocking (they run on the worker thread).
 
 **Integration tests** (`tests/integration/`): Tests that spawn actual node processes. `twonodessuite` / `multinodesuite` macros set up N nodes and `StorageClient` (HTTP client) for interacting with them.
 

--- a/library/README.md
+++ b/library/README.md
@@ -100,14 +100,13 @@ void *storage_new(
 Typical usage:
 - `storage_new(...)`
 - `storage_start(...)`
-- `storage_stop(...)`
-- `storage_destroy(...)`
+- `storage_shutdown(...)`
 
 ---
 
 ### `storage_start`
 
-Start the Logos Storage node (can be started/stopped multiple times).
+Start the Logos Storage node.
 
 ```c
 int storage_start(void *ctx, StorageCallback callback, void *userData);
@@ -115,33 +114,14 @@ int storage_start(void *ctx, StorageCallback callback, void *userData);
 
 ---
 
-### `storage_stop`
+### `storage_shutdown`
 
-Stop the Logos Storage node (can be started/stopped multiple times).
-
-```c
-int storage_stop(void *ctx, StorageCallback callback, void *userData);
-```
-
----
-
-### `storage_close`
-
-Close the node and release resources before destruction.
+Cleanly shuts down and destroys the node instance. After this call is accepted,
+the context belongs to libstorage and must not be used again. Completion is
+reported through the callback.
 
 ```c
-int storage_close(void *ctx, StorageCallback callback, void *userData);
-```
-
----
-
-### `storage_destroy`
-
-Destroys the node instance and frees associated resources. Node must be stopped and closed.
-The call is synchronous, so it does not require a callback.
-
-```c
-int storage_destroy(void *ctx);
+int storage_shutdown(void *ctx, StorageCallback callback, void *userData);
 ```
 
 ---

--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -54,8 +54,7 @@ extern "C"
     // ctx = storage_new(configJson, myCallback, myUserData);
     // storage_start(ctx, ...);
     // ...
-    // storage_stop(ctx, ...);
-    // storage_destroy(ctx, ...);
+    // storage_shutdown(ctx, ...);
     void *storage_new(
         const char *configJson,
         StorageCallback callback,
@@ -353,57 +352,35 @@ extern "C"
         void *userData);
 
     // Start the Logos Storage node.
-    // The node can be started and stopped multiple times.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);
     // storage_start(ctx, ...);
     // ...
-    // storage_stop(ctx, ...);
-    // storage_destroy(ctx, ...);
+    // storage_shutdown(ctx, ...);
     int storage_start(void *ctx,
                       StorageCallback callback,
                       void *userData);
 
-    // Stop the Logos Storage node.
-    // The node can be started and stopped multiple times.
+    // Cleanly shuts down and destroys an instance of a Logos Storage node.
+    //
+    // This operation stops active node services, closes node resources, then
+    // frees the underlying StorageContext. If this function returns RET_OK,
+    // libstorage has accepted ownership of `ctx`; callers must not pass `ctx`
+    // to any other libstorage API afterwards. The callback is invoked once the
+    // shutdown is complete and `ctx` is invalid.
+    //
+    // If this function returns RET_ERR or RET_MISSING_CALLBACK, ownership was
+    // not accepted and the caller still owns `ctx`.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);
     // storage_start(ctx, ...);
     // ...
-    // storage_stop(ctx, ...);
-    // storage_destroy(ctx, ...);
-    int storage_stop(void *ctx,
-                     StorageCallback callback,
-                     void *userData);
-
-    // Close the Logos Storage node.
-    // Use this to release resources before destroying the node.
-    //
-    // Typical usage:
-    // ctx = storage_new(configJson, myCallback, myUserData);
-    // storage_start(ctx, ...);
-    // ...
-    // storage_stop(ctx, ...);
-    // storage_close(ctx, ...);
-    int storage_close(void *ctx,
-                      StorageCallback callback,
-                      void *userData);
-
-    // Destroys an instance of a Logos Storage node.
-    // This will free all resources associated with the node.
-    // The node must be stopped and closed before calling this function.
-    // The call is synchronous, so it does not require a callback.
-    //
-    // Typical usage:
-    // ctx = storage_new(configJson, myCallback, myUserData);
-    // storage_start(ctx, ...);
-    // ...
-    // storage_stop(ctx, ...);
-    // storage_close(ctx, ...);
-    // storage_destroy(ctx, ...);
-    int storage_destroy(void *ctx);
+    // storage_shutdown(ctx, ...);
+    int storage_shutdown(void *ctx,
+                         StorageCallback callback,
+                         void *userData);
 
     // Not used currently.
     // Reserved for future use to set an event callback.

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -453,7 +453,6 @@ proc storage_shutdown(
 
   var sentOk = false
   var signalOk = false
-  var rollbackOk = false
   shutdownSupervisor.lock.acquire()
   try:
     sentOk = shutdownSupervisor.reqChannel.trySend(sctx)
@@ -462,8 +461,7 @@ proc storage_shutdown(
       signalOk = fireRes.isOk and fireRes.get()
       if not signalOk:
         var queuedCtx: ptr ShutdownContext
-        let recvOk = shutdownSupervisor.reqChannel.tryRecv(queuedCtx)
-        rollbackOk = recvOk and queuedCtx == sctx
+        discard shutdownSupervisor.reqChannel.tryRecv(queuedCtx)
   finally:
     shutdownSupervisor.lock.release()
 
@@ -476,7 +474,6 @@ proc storage_shutdown(
     )
 
   if not signalOk:
-    doAssert rollbackOk
     discard doneSignal.close()
     deallocShared(sctx)
     return callback.error(

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -259,6 +259,11 @@ proc storage_new(
     error "Failed to create Storage instance: the callback is missing."
     return nil
 
+  if not shutdownSupervisorReady.load:
+    let msg = "Failed to create Storage instance: shutdown supervisor is not initialized."
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return nil
+
   var ctx = storage_context.createStorageContext().valueOr:
     let msg = $error
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -451,9 +451,21 @@ proc storage_shutdown(
       userData,
     )
 
+  var sentOk = false
+  var signalOk = false
+  var rollbackOk = false
   shutdownSupervisor.lock.acquire()
-  let sentOk = shutdownSupervisor.reqChannel.trySend(sctx)
-  shutdownSupervisor.lock.release()
+  try:
+    sentOk = shutdownSupervisor.reqChannel.trySend(sctx)
+    if sentOk:
+      let fireRes = shutdownSupervisor.reqSignal.fireSync()
+      signalOk = fireRes.isOk and fireRes.get()
+      if not signalOk:
+        var queuedCtx: ptr ShutdownContext
+        let recvOk = shutdownSupervisor.reqChannel.tryRecv(queuedCtx)
+        rollbackOk = recvOk and queuedCtx == sctx
+  finally:
+    shutdownSupervisor.lock.release()
 
   if not sentOk:
     discard doneSignal.close()
@@ -463,26 +475,14 @@ proc storage_shutdown(
       userData,
     )
 
-  let fireRes = shutdownSupervisor.reqSignal.fireSync()
-  if fireRes.isErr or fireRes.get() == false:
-    var queuedCtx: ptr ShutdownContext
-    var recvOk = false
-    shutdownSupervisor.lock.acquire()
-    try:
-      recvOk = shutdownSupervisor.reqChannel.tryRecv(queuedCtx)
-    finally:
-      shutdownSupervisor.lock.release()
-
-    if recvOk and queuedCtx == sctx:
-      discard doneSignal.close()
-      deallocShared(sctx)
-      return callback.error(
-        "Failed to shutdown Logos Storage context: unable to signal shutdown supervisor.",
-        userData,
-      )
-
-    warn "Failed to signal Logos Storage shutdown supervisor after shutdown request was accepted."
-    return RET_OK
+  if not signalOk:
+    doAssert rollbackOk
+    discard doneSignal.close()
+    deallocShared(sctx)
+    return callback.error(
+      "Failed to shutdown Logos Storage context: unable to signal shutdown supervisor.",
+      userData,
+    )
 
   return RET_OK
 

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -24,10 +24,12 @@ when defined(linux):
   # Define the canonical name for this library
   {.passl: "-Wl,-soname,libstorage.so".}
 
-import std/[atomics]
+import std/[atomics, exitprocs, locks]
 import chronicles
 import chronos
 import chronos/threadsync
+import results
+import taskpools/channels_spsc_single
 import ./storage_context
 import ./storage_thread_requests/storage_thread_request
 import ./storage_thread_requests/requests/node_lifecycle_request
@@ -53,6 +55,17 @@ type ShutdownContext = object
   ret: cint
   msg: ptr cchar
   len: csize_t
+
+type ShutdownSupervisor = object
+  thread: Thread[void]
+  lock: Lock
+  reqChannel: ChannelSPSCSingle[ptr ShutdownContext]
+  reqSignal: ThreadSignalPtr
+  running: Atomic[bool]
+
+var
+  shutdownSupervisor: ShutdownSupervisor
+  shutdownSupervisorReady: Atomic[bool]
 
 template checkLibstorageParams*(
     ctx: ptr StorageContext, callback: StorageCallback, userData: pointer
@@ -114,7 +127,7 @@ proc shutdownStorageCallback(
   setShutdownResult(sctx, ret, msg, len)
   discard sctx[].doneSignal.fireSync()
 
-proc runShutdown(sctx: ptr ShutdownContext) {.thread.} =
+proc runShutdown(sctx: ptr ShutdownContext) =
   if isNil(sctx):
     return
 
@@ -150,6 +163,62 @@ proc runShutdown(sctx: ptr ShutdownContext) {.thread.} =
   discard sctx[].doneSignal.close()
   deallocShared(sctx)
 
+proc runShutdownSupervisor() {.thread.} =
+  while true:
+    let waitRes = shutdownSupervisor.reqSignal.waitSync(InfiniteDuration)
+    if waitRes.isErr:
+      error "Failure in Logos Storage shutdown supervisor while waiting for reqSignal.",
+        error = waitRes.error
+      continue
+
+    var sctx: ptr ShutdownContext
+    var recvOk = false
+    shutdownSupervisor.lock.acquire()
+    try:
+      recvOk = shutdownSupervisor.reqChannel.tryRecv(sctx)
+    finally:
+      shutdownSupervisor.lock.release()
+
+    if recvOk:
+      runShutdown(sctx)
+
+    if shutdownSupervisor.running.load == false:
+      break
+
+proc stopShutdownSupervisor() {.noconv.} =
+  if not shutdownSupervisorReady.exchange(false):
+    return
+
+  shutdownSupervisor.running.store(false)
+  discard shutdownSupervisor.reqSignal.fireSync()
+  joinThread(shutdownSupervisor.thread)
+
+  shutdownSupervisor.lock.deinitLock()
+  discard shutdownSupervisor.reqSignal.close()
+
+proc startShutdownSupervisor(): Result[void, string] =
+  shutdownSupervisor.reqSignal = ThreadSignalPtr.new().valueOr:
+    return err(
+      "Failed to initialize Logos Storage shutdown supervisor: unable to create reqSignal."
+    )
+
+  shutdownSupervisor.lock.initLock()
+  shutdownSupervisor.running.store(true)
+
+  try:
+    createThread(shutdownSupervisor.thread, runShutdownSupervisor)
+  except ValueError, ResourceExhaustedError:
+    shutdownSupervisor.lock.deinitLock()
+    discard shutdownSupervisor.reqSignal.close()
+    return err(
+      "Failed to initialize Logos Storage shutdown supervisor: unable to create thread: " &
+        getCurrentExceptionMsg()
+    )
+
+  shutdownSupervisorReady.store(true)
+  addExitProc(stopShutdownSupervisor)
+  return ok()
+
 # From Nim doc:
 # "the C targets require you to initialize Nim's internals, which is done calling a NimMain function."
 # "The name NimMain can be influenced via the --nimMainPrefix:prefix switch."
@@ -172,6 +241,8 @@ proc initializeLibrary() {.exported.} =
   if not initialized.exchange(true):
     ## Every Nim library must call `<prefix>NimMain()` once
     libstorageNimMain()
+    startShutdownSupervisor().isOkOr:
+      error "Failed to initialize Logos Storage shutdown supervisor.", error = error
   when declared(setupForeignThreadGc):
     setupForeignThreadGc()
   when declared(nimGC_setStackBottom):
@@ -367,17 +438,46 @@ proc storage_shutdown(
   sctx[].doneSignal = doneSignal
   sctx[].ret = RET_ERR
 
-  var shutdownThread: Thread[ptr ShutdownContext]
-  try:
-    createThread(shutdownThread, runShutdown, sctx)
-  except ValueError, ResourceExhaustedError:
+  if not shutdownSupervisorReady.load:
     discard doneSignal.close()
     deallocShared(sctx)
     return callback.error(
-      "Failed to shutdown Logos Storage context: unable to create shutdown thread: " &
-        getCurrentExceptionMsg(),
+      "Failed to shutdown Logos Storage context: shutdown supervisor is not initialized.",
       userData,
     )
+
+  shutdownSupervisor.lock.acquire()
+  let sentOk = shutdownSupervisor.reqChannel.trySend(sctx)
+  shutdownSupervisor.lock.release()
+
+  if not sentOk:
+    discard doneSignal.close()
+    deallocShared(sctx)
+    return callback.error(
+      "Failed to shutdown Logos Storage context: shutdown supervisor is busy.",
+      userData,
+    )
+
+  let fireRes = shutdownSupervisor.reqSignal.fireSync()
+  if fireRes.isErr or fireRes.get() == false:
+    var queuedCtx: ptr ShutdownContext
+    var recvOk = false
+    shutdownSupervisor.lock.acquire()
+    try:
+      recvOk = shutdownSupervisor.reqChannel.tryRecv(queuedCtx)
+    finally:
+      shutdownSupervisor.lock.release()
+
+    if recvOk and queuedCtx == sctx:
+      discard doneSignal.close()
+      deallocShared(sctx)
+      return callback.error(
+        "Failed to shutdown Logos Storage context: unable to signal shutdown supervisor.",
+        userData,
+      )
+
+    warn "Failed to signal Logos Storage shutdown supervisor after shutdown request was accepted."
+    return RET_OK
 
   return RET_OK
 

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -45,6 +45,15 @@ from ../storage/conf import storageVersion
 logScope:
   topics = "libstorage"
 
+type ShutdownContext = object
+  ctx: ptr StorageContext
+  callback: StorageCallback
+  userData: pointer
+  doneSignal: ThreadSignalPtr
+  ret: cint
+  msg: ptr cchar
+  len: csize_t
+
 template checkLibstorageParams*(
     ctx: ptr StorageContext, callback: StorageCallback, userData: pointer
 ) =
@@ -65,6 +74,81 @@ proc asNewCString(s: string): ptr cchar =
     copyMem(cstr, addr s[0], n)
   cstr[n] = 0.cchar
   cast[ptr cchar](cstr)
+
+proc copySharedMsg(msg: ptr cchar, len: csize_t): ptr cchar =
+  if isNil(msg) or len == 0:
+    return nil
+
+  let size = len + 1
+  let copied = cast[ptr cchar](allocShared(size))
+  let bytes = cast[ptr UncheckedArray[cchar]](copied)
+  copyMem(copied, msg, len)
+  bytes[len] = '\0'
+  return copied
+
+proc setShutdownResult(
+    sctx: ptr ShutdownContext, ret: cint, msg: ptr cchar, len: csize_t
+) =
+  if not isNil(sctx[].msg):
+    deallocShared(sctx[].msg)
+    sctx[].msg = nil
+
+  sctx[].ret = ret
+  sctx[].msg = copySharedMsg(msg, len)
+  sctx[].len = len
+
+proc setShutdownError(sctx: ptr ShutdownContext, msg: string) =
+  if msg.len == 0:
+    setShutdownResult(sctx, RET_ERR, nil, 0)
+    return
+
+  setShutdownResult(sctx, RET_ERR, unsafeAddr msg[0], cast[csize_t](msg.len))
+
+proc shutdownStorageCallback(
+    ret: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.callback.} =
+  let sctx = cast[ptr ShutdownContext](userData)
+  if isNil(sctx):
+    return
+
+  setShutdownResult(sctx, ret, msg, len)
+  discard sctx[].doneSignal.fireSync()
+
+proc runShutdown(sctx: ptr ShutdownContext) {.thread.} =
+  if isNil(sctx):
+    return
+
+  let reqContent: ptr NodeLifecycleRequest =
+    NodeLifecycleRequest.createShared(NodeLifecycleMsgType.SHUTDOWN_NODE)
+  let dispatchRes = storage_context.sendRequestToStorageThread(
+    sctx[].ctx,
+    RequestType.LIFECYCLE,
+    reqContent,
+    shutdownStorageCallback,
+    cast[pointer](sctx),
+  )
+
+  if dispatchRes.isOk:
+    let waitRes = sctx[].doneSignal.waitSync(InfiniteDuration)
+    if waitRes.isErr:
+      setShutdownError(
+        sctx,
+        "Failed to shutdown Logos Storage context: unable to receive shutdown result.",
+      )
+  else:
+    setShutdownError(sctx, dispatchRes.error)
+
+  let destroyRes = storage_context.destroyStorageContext(sctx[].ctx)
+  if destroyRes.isErr and sctx[].ret == RET_OK:
+    setShutdownError(sctx, destroyRes.error)
+
+  foreignThreadGc:
+    sctx[].callback(sctx[].ret, sctx[].msg, sctx[].len, sctx[].userData)
+
+  if not isNil(sctx[].msg):
+    deallocShared(sctx[].msg)
+  discard sctx[].doneSignal.close()
+  deallocShared(sctx)
 
 # From Nim doc:
 # "the C targets require you to initialize Nim's internals, which is done calling a NimMain function."
@@ -259,25 +343,43 @@ proc storage_peer_debug(
 
   return callback.okOrError(res, userData)
 
-proc storage_close(
+proc storage_shutdown(
     ctx: ptr StorageContext, callback: StorageCallback, userData: pointer
 ): cint {.dynlib, exportc.} =
   initializeLibrary()
-  checkLibstorageParams(ctx, callback, userData)
 
-  let reqContent = NodeLifecycleRequest.createShared(NodeLifecycleMsgType.CLOSE_NODE)
-  var res = storage_context.sendRequestToStorageThread(
-    ctx, RequestType.LIFECYCLE, reqContent, callback, userData
-  )
-  if res.isErr:
-    return callback.error(res.error, userData)
+  if isNil(callback):
+    return RET_MISSING_CALLBACK
 
-  return callback.okOrError(res, userData)
+  if isNil(ctx):
+    return callback.error("Storage context not initialized.", userData)
 
-proc storage_destroy(ctx: ptr StorageContext): cint {.dynlib, exportc.} =
-  initializeLibrary()
-  let res = storage_context.destroyStorageContext(ctx)
-  if res.isErr: RET_ERR else: RET_OK
+  let doneSignal = ThreadSignalPtr.new().valueOr:
+    return callback.error(
+      "Failed to shutdown Logos Storage context: unable to create done signal.",
+      userData,
+    )
+
+  let sctx = createShared(ShutdownContext, 1)
+  sctx[].ctx = ctx
+  sctx[].callback = callback
+  sctx[].userData = userData
+  sctx[].doneSignal = doneSignal
+  sctx[].ret = RET_ERR
+
+  var shutdownThread: Thread[ptr ShutdownContext]
+  try:
+    createThread(shutdownThread, runShutdown, sctx)
+  except ValueError, ResourceExhaustedError:
+    discard doneSignal.close()
+    deallocShared(sctx)
+    return callback.error(
+      "Failed to shutdown Logos Storage context: unable to create shutdown thread: " &
+        getCurrentExceptionMsg(),
+      userData,
+    )
+
+  return RET_OK
 
 proc storage_upload_init(
     ctx: ptr StorageContext,
@@ -556,20 +658,6 @@ proc storage_start(
 
   let reqContent: ptr NodeLifecycleRequest =
     NodeLifecycleRequest.createShared(NodeLifecycleMsgType.START_NODE)
-  let res = storage_context.sendRequestToStorageThread(
-    ctx, RequestType.LIFECYCLE, reqContent, callback, userData
-  )
-
-  return callback.okOrError(res, userData)
-
-proc storage_stop(
-    ctx: ptr StorageContext, callback: StorageCallback, userData: pointer
-): cint {.dynlib, exportc.} =
-  initializeLibrary()
-  checkLibstorageParams(ctx, callback, userData)
-
-  let reqContent: ptr NodeLifecycleRequest =
-    NodeLifecycleRequest.createShared(NodeLifecycleMsgType.STOP_NODE)
   let res = storage_context.sendRequestToStorageThread(
     ctx, RequestType.LIFECYCLE, reqContent, callback, userData
   )

--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -52,7 +52,7 @@ type StorageContext* = object
   # returned with every event callback
   eventUserData*: pointer
 
-  # Set to false to stop the Logos Storage thread (during storage_destroy)
+  # Set to false to stop the Logos Storage thread during context shutdown.
   running: Atomic[bool]
 
 template callEventCallback(ctx: ptr StorageContext, eventName: string, body: untyped) =
@@ -135,7 +135,7 @@ proc runStorage(ctx: ptr StorageContext) {.async: (raises: []).} =
         error = e.msg
       continue
 
-    # If storage_destroy was called, exit the loop
+    # If context shutdown was requested, exit the loop.
     if ctx.running.load == false:
       break
 
@@ -188,7 +188,7 @@ proc createStorageContext*(): Result[ptr StorageContext, string] =
   # Protects shared state inside StorageContext
   ctx.lock.initLock()
 
-  # Logos Storage thread will loop until storage_destroy is called
+  # Logos Storage thread will loop until context shutdown is requested.
   ctx.running.store(true)
 
   try:

--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -217,6 +217,10 @@ proc destroyStorageContext*(ctx: ptr StorageContext): Result[void, string] =
   # Wait for the thread to finish
   joinThread(ctx.thread)
 
+  var request: ptr StorageThreadRequest
+  while ctx.reqChannel.tryRecv(request):
+    destroyShared(request)
+
   # Clean up
   ctx.lock.deinitLock()
   ?ctx.reqSignal.close()

--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -94,27 +94,26 @@ proc sendRequestToStorageThread*(
   # Send the request to the Logos Storage thread
   let sentOk = ctx.reqChannel.trySend(req)
   if not sentOk:
-    deallocShared(req)
+    destroyShared(req)
     return err("Failed to send request to the Logos Storage thread: " & $req[])
 
   # Notify the Logos Storage thread that a request is available
   let fireSyncRes = ctx.reqSignal.fireSync()
   if fireSyncRes.isErr():
-    deallocShared(req)
+    destroyShared(req)
     return err(
       "Failed to send request to the Logos Storage thread: unable to fireSync: " &
         $fireSyncRes.error
     )
 
   if fireSyncRes.get() == false:
-    deallocShared(req)
+    destroyShared(req)
     return
       err("Failed to send request to the Logos Storage thread: fireSync timed out.")
 
   # Wait until the Logos Storage thread properly received the request
   let res = ctx.reqReceivedSignal.waitSync(timeout)
   if res.isErr():
-    deallocShared(req)
     return err(
       "Failed to send request to the Logos Storage thread: unable to receive reqReceivedSignal signal."
     )

--- a/library/storage_thread_requests/requests/node_debug_request.nim
+++ b/library/storage_thread_requests/requests/node_debug_request.nim
@@ -41,7 +41,7 @@ proc createShared*(
   ret[].logLevel = logLevel.alloc()
   return ret
 
-proc destroyShared(self: ptr NodeDebugRequest) =
+proc destroyShared*(self: ptr NodeDebugRequest) =
   deallocShared(self[].peerId)
   deallocShared(self[].logLevel)
   deallocShared(self)

--- a/library/storage_thread_requests/requests/node_download_request.nim
+++ b/library/storage_thread_requests/requests/node_download_request.nim
@@ -72,7 +72,7 @@ proc createShared*(
 
   return ret
 
-proc destroyShared(self: ptr NodeDownloadRequest) =
+proc destroyShared*(self: ptr NodeDownloadRequest) =
   deallocShared(self[].cid)
   deallocShared(self[].filepath)
   deallocShared(self)

--- a/library/storage_thread_requests/requests/node_info_request.nim
+++ b/library/storage_thread_requests/requests/node_info_request.nim
@@ -31,7 +31,7 @@ proc createShared*(T: type NodeInfoRequest, op: NodeInfoMsgType): ptr type T =
   ret[].operation = op
   return ret
 
-proc destroyShared(self: ptr NodeInfoRequest) =
+proc destroyShared*(self: ptr NodeInfoRequest) =
   deallocShared(self)
 
 proc getRepo(

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -1,7 +1,7 @@
 ## This file contains the lifecycle request type that will be handled.
 ## CREATE_NODE: create a new Logos Storage node with the provided config.json.
 ## START_NODE: start the provided Logos Storage node.
-## STOP_NODE: stop the provided Logos Storage node.
+## SHUTDOWN_NODE: stop and close the provided Logos Storage node.
 
 import std/[options, json, strutils, net, os]
 import codexdht/discv5/spr
@@ -22,7 +22,7 @@ import ../../../storage/utils
 import ../../../storage/utils/[keyutils, fileutils]
 import ../../../storage/units
 
-from ../../../storage/storage import StorageServer, new, start, stop, close
+from ../../../storage/storage import StorageServer, new, start, shutdown
 
 logScope:
   topics = "libstorage libstoragelifecycle"
@@ -32,8 +32,7 @@ const LibstorageDisableRestApi* {.booldefine.} = true
 type NodeLifecycleMsgType* = enum
   CREATE_NODE
   START_NODE
-  STOP_NODE
-  CLOSE_NODE
+  SHUTDOWN_NODE
 
 proc readValue*[T: InputFile | InputDir | OutPath | OutDir | OutFile](
     r: var JsonReader, val: var T
@@ -184,16 +183,10 @@ proc process*(
     except Exception as e:
       error "Failed to START_NODE.", error = e.msg
       return err(e.msg)
-  of STOP_NODE:
+  of SHUTDOWN_NODE:
     try:
-      await storage[].stop()
+      await storage[].shutdown()
     except Exception as e:
-      error "Failed to STOP_NODE.", error = e.msg
-      return err(e.msg)
-  of CLOSE_NODE:
-    try:
-      await storage[].close()
-    except Exception as e:
-      error "Failed to CLOSE_NODE.", error = e.msg
+      error "Failed to SHUTDOWN_NODE.", error = e.msg
       return err(e.msg)
   return ok("")

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -89,7 +89,7 @@ proc createShared*(
   ret[].configJson = configJson.alloc()
   return ret
 
-proc destroyShared(self: ptr NodeLifecycleRequest) =
+proc destroyShared*(self: ptr NodeLifecycleRequest) =
   deallocShared(self[].configJson)
   deallocShared(self)
 

--- a/library/storage_thread_requests/requests/node_mix_request.nim
+++ b/library/storage_thread_requests/requests/node_mix_request.nim
@@ -15,7 +15,7 @@ proc createShared*(T: type NodeMixRequest, privateQueries: bool): ptr type T =
   ret[].privateQueries = privateQueries
   return ret
 
-proc destroyShared(self: ptr NodeMixRequest) =
+proc destroyShared*(self: ptr NodeMixRequest) =
   deallocShared(self)
 
 proc process*(

--- a/library/storage_thread_requests/requests/node_p2p_request.nim
+++ b/library/storage_thread_requests/requests/node_p2p_request.nim
@@ -35,7 +35,7 @@ proc createShared*(
   ret[].peerAddresses = peerAddresses
   return ret
 
-proc destroyShared(self: ptr NodeP2PRequest) =
+proc destroyShared*(self: ptr NodeP2PRequest) =
   deallocShared(self[].peerId)
   deallocShared(self)
 

--- a/library/storage_thread_requests/requests/node_storage_request.nim
+++ b/library/storage_thread_requests/requests/node_storage_request.nim
@@ -50,7 +50,7 @@ proc createShared*(
 
   return ret
 
-proc destroyShared(self: ptr NodeStorageRequest) =
+proc destroyShared*(self: ptr NodeStorageRequest) =
   deallocShared(self[].cid)
   deallocShared(self)
 

--- a/library/storage_thread_requests/requests/node_upload_request.nim
+++ b/library/storage_thread_requests/requests/node_upload_request.nim
@@ -80,7 +80,7 @@ proc createShared*(
 
   return ret
 
-proc destroyShared(self: ptr NodeUploadRequest) =
+proc destroyShared*(self: ptr NodeUploadRequest) =
   deallocShared(self[].filepath)
   deallocShared(self[].sessionId)
   deallocShared(self)

--- a/library/storage_thread_requests/storage_thread_request.nim
+++ b/library/storage_thread_requests/storage_thread_request.nim
@@ -54,6 +54,27 @@ proc createShared*(
   ret[].userData = userData
   return ret
 
+proc destroyShared*(request: ptr StorageThreadRequest) =
+  case request[].reqType
+  of LIFECYCLE:
+    destroyShared(cast[ptr NodeLifecycleRequest](request[].reqContent))
+  of INFO:
+    destroyShared(cast[ptr NodeInfoRequest](request[].reqContent))
+  of RequestType.DEBUG:
+    destroyShared(cast[ptr NodeDebugRequest](request[].reqContent))
+  of P2P:
+    destroyShared(cast[ptr NodeP2PRequest](request[].reqContent))
+  of STORAGE:
+    destroyShared(cast[ptr NodeStorageRequest](request[].reqContent))
+  of DOWNLOAD:
+    destroyShared(cast[ptr NodeDownloadRequest](request[].reqContent))
+  of UPLOAD:
+    destroyShared(cast[ptr NodeUploadRequest](request[].reqContent))
+  of MIX:
+    destroyShared(cast[ptr NodeMixRequest](request[].reqContent))
+
+  deallocShared(request)
+
 # NOTE: User callbacks are executed on the working thread.
 # They must be fast and non-blocking; otherwise this thread will be blocked
 # and no further requests can be processed.

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -342,35 +342,14 @@ int cleanup(void *storage_ctx)
 {
     Resp *r = alloc_resp();
 
-    // Stop node
-    if (storage_stop(storage_ctx, (StorageCallback)callback, r) != RET_OK)
+    // storage_shutdown owns and invalidates storage_ctx after successful dispatch.
+    if (storage_shutdown(storage_ctx, (StorageCallback)callback, r) != RET_OK)
     {
         free_resp(r);
         return RET_ERR;
     }
 
     if (is_resp_ok(r, NULL) != RET_OK)
-    {
-        return RET_ERR;
-    }
-
-    r = alloc_resp();
-
-    // Close node
-    if (storage_close(storage_ctx, (StorageCallback)callback, r) != RET_OK)
-    {
-        free_resp(r);
-        return RET_ERR;
-    }
-
-    if (is_resp_ok(r, NULL) != RET_OK)
-    {
-        return RET_ERR;
-    }
-
-    // Destroy node
-    // No need to wait here as storage_destroy is synchronous
-    if (storage_destroy(storage_ctx) != RET_OK)
     {
         return RET_ERR;
     }

--- a/tools/libstorage-cpp/.gitignore
+++ b/tools/libstorage-cpp/.gitignore
@@ -1,0 +1,12 @@
+storage_lib_cli
+storage_lib
+storage_lib_ctl
+storage-lib-cli-data/
+storage-lib-data/
+storage_lib.sock
+daemon.log
+downloaded*
+*.download
+*.download.*
+*.roundtrip
+*.out.*

--- a/tools/libstorage-cpp/AGENTS.md
+++ b/tools/libstorage-cpp/AGENTS.md
@@ -1,0 +1,177 @@
+# Libstorage C++ Tooling Notes
+
+This folder contains small C++ tools built on top of `library/libstorage.h`.
+
+## Components
+
+- `storage_client.hpp`: shared wrapper declarations and result structs.
+- `storage_client.cpp`: shared wrapper implementation around the async libstorage C API.
+- `storage_lib_cli.cpp`: one-shot command-line tool that starts a libstorage node, runs one command, and exits.
+- `storage_lib.cpp`: long-running libstorage daemon with Unix socket IPC.
+- `storage_lib_ctl.cpp`: control client that sends one IPC command to `storage_lib`.
+- `Makefile`: builds `storage_lib_cli`, `storage_lib`, and `storage_lib_ctl` against `../../build/libstorage.so`.
+- `README.md`: operator-facing usage notes.
+
+`tools/storage-test/` consumes the daemon target through `storage_lib_ctl`.
+
+## Build Notes
+
+Build libstorage first. On the current AMD Ryzen AI 9 HX 370 machine, use:
+
+```bash
+make libstorage NIMFLAGS="-d:disableMarchNative"
+```
+
+This avoids the known GCC/secp256k1 x86_64 asm failure caused by `-march=native`.
+
+Then build the C++ tools:
+
+```bash
+cd tools/libstorage-cpp
+make
+```
+
+The Makefile links explicitly against `../../build/libstorage.so`. If only `libstorage.a` exists, build the shared library first with `make libstorage`.
+
+## StorageClient Behavior
+
+`StorageClient` wraps the async libstorage C API with blocking helper methods.
+
+Important callback behavior:
+
+- `RET_PROGRESS` is intermediate and must not complete a wait.
+- `RET_OK` and `RET_ERR` are terminal.
+- Callbacks run on libstorage worker context; keep callback logic fast and non-blocking.
+
+Timeout behavior:
+
+- Positive `timeout_ms` waits up to that duration.
+- `timeout_ms == 0` waits indefinitely.
+
+Follow the existing pattern of returning structured results instead of throwing. Keep the C++ wrapper small and direct.
+
+## CLI vs Daemon Responsibilities
+
+`storage_lib_cli` is for one-shot checks and manual experiments.
+
+`storage_lib` is a primitive daemon that keeps one libstorage node alive across commands.
+
+Keep daemon commands low-level:
+
+- `info`
+- `version`
+- `revision`
+- `repo`
+- `peer-id`
+- `spr`
+- `debug`
+- `metrics`
+- `list`
+- `space`
+- `upload`
+- `download`
+- `exists`
+- `delete`
+- `fetch`
+- `stream-sink`
+- `manifest`
+- `connect`
+- `shutdown`
+- `destroy`
+
+Do not add scenario commands like `roundtrip`, `many`, or cross-target tests to the daemon unless explicitly requested. Put scenario orchestration in `tools/storage-test/storage-test.sh` so the same scenario can run against REST targets and the libstorage daemon target.
+
+## Daemon IPC
+
+`storage_lib` listens on a Unix domain socket.
+
+Protocol:
+
+- One client connection per command.
+- Request is one whitespace-separated line.
+- Response is one JSON line.
+- Success shape: `{"ok":true,"result":"..."}`.
+- Failure shape: `{"ok":false,"error":"..."}`.
+
+The protocol currently does not support paths or arguments containing spaces. If that becomes important, prefer moving to JSON requests rather than adding ad-hoc escaping.
+
+`storage_lib_ctl` socket resolution order:
+
+1. `--socket <path>`
+2. `STORAGE_LIB_SOCKET`
+3. `~/.logos/storage/libstorage/storage_lib.sock`
+
+`storage_lib_ctl` should return nonzero when the daemon responds with `"ok":false`.
+
+Lifecycle IPC commands are daemon-level state controls over the libstorage C API:
+
+- The daemon starts one libstorage node during process startup.
+- `shutdown` and `destroy` are aliases; both call `StorageClient::shutdown()`, which uses `storage_shutdown()` to stop, close, and free the libstorage context before stopping the daemon loop.
+- Do not expose lower-level `start`, `stop`, or `close` IPC commands; normal clients should use the daemon as running-until-shutdown.
+
+`stream-sink <cid> [local]` uses released libstorage download primitives: `storage_download_init` followed by `storage_download_stream` with an empty output path. It discards progress bytes while counting transferred byte lengths and waits for terminal completion.
+
+File paths sent over IPC are resolved by the daemon process. Callers that run from a different working directory, such as `tools/storage-test/storage-test.sh`, should send absolute paths.
+
+## Daemon Options
+
+Current daemon options include:
+
+- `--data-dir`
+- `--socket`
+- `--log-level`
+- `--listen-port`
+- `--disc-port`
+- `--network`
+- `--chunk-size`
+- `--timeout-ms`
+
+Use a distinct data directory from any running standard storage node to avoid datastore locking conflicts.
+
+Default libstorage daemon paths used by storage-test tooling:
+
+- Data dir: `~/.logos/storage/libstorage/node`
+- Socket: `~/.logos/storage/libstorage/storage_lib.sock`
+
+## Verification
+
+Lightweight build and smoke-check flow:
+
+```bash
+make libstorage NIMFLAGS="-d:disableMarchNative"
+cd tools/libstorage-cpp
+make
+```
+
+Run daemon from repo root or with absolute paths:
+
+```bash
+tools/libstorage-cpp/storage_lib --data-dir /tmp/storage-lib-data --socket /tmp/storage-lib.sock --log-level FATAL --timeout-ms 0
+```
+
+In another shell:
+
+```bash
+tools/libstorage-cpp/storage_lib_ctl --socket /tmp/storage-lib.sock info
+tools/libstorage-cpp/storage_lib_ctl --socket /tmp/storage-lib.sock peer-id
+tools/libstorage-cpp/storage_lib_ctl --socket /tmp/storage-lib.sock shutdown
+```
+
+Storage-test integration smoke checks:
+
+```bash
+tools/storage-test/start-local-node.sh --client lib --data-dir /tmp/storage-lib-data --socket /tmp/storage-lib.sock --log-level FATAL --timeout-ms 0
+STORAGE_LIB_SOCKET=/tmp/storage-lib.sock tools/storage-test/storage-test.sh lib peerid
+STORAGE_LIB_SOCKET=/tmp/storage-lib.sock tools/libstorage-cpp/storage_lib_ctl shutdown
+```
+
+Full `tools/storage-test/storage-test.sh lib test` contacts the configured remote Linode and performs real uploads/downloads. Run it deliberately.
+
+## Style Guidance
+
+- Keep the wrapper minimal and boring.
+- Prefer small local functions over broad abstractions.
+- Do not add backward-compatible command aliases unless there is an explicit need.
+- Keep scenario logic out of `storage_lib`.
+- Preserve JSON responses for daemon IPC so shell scripts can parse success/failure reliably.
+- Avoid blocking work in libstorage callbacks.

--- a/tools/libstorage-cpp/Makefile
+++ b/tools/libstorage-cpp/Makefile
@@ -1,0 +1,34 @@
+CXX := g++
+CXXFLAGS := -std=c++17 -Wall -Wextra -O2 -I../../library
+LIBSTORAGE := ../../build/libstorage.so
+LDFLAGS := $(LIBSTORAGE) -pthread
+RPATH := -Wl,-rpath,'$$ORIGIN/../../build'
+
+TARGETS := storage_lib_cli storage_lib storage_lib_ctl
+COMMON_SRCS := storage_client.cpp
+
+.PHONY: all clean run
+
+all: $(TARGETS)
+
+storage_lib_cli: storage_lib_cli.cpp $(COMMON_SRCS) storage_client.hpp $(LIBSTORAGE)
+	$(CXX) $(CXXFLAGS) storage_lib_cli.cpp $(COMMON_SRCS) -o $@ $(LDFLAGS) $(RPATH)
+
+storage_lib: storage_lib.cpp $(COMMON_SRCS) storage_client.hpp $(LIBSTORAGE)
+	$(CXX) $(CXXFLAGS) storage_lib.cpp $(COMMON_SRCS) -o $@ $(LDFLAGS) $(RPATH)
+
+storage_lib_ctl: storage_lib_ctl.cpp
+	$(CXX) $(CXXFLAGS) storage_lib_ctl.cpp -o $@
+
+$(LIBSTORAGE):
+	@echo "Missing $(LIBSTORAGE). Run 'make libstorage' from the repository root first." >&2
+	@exit 1
+
+run: storage_lib_cli
+	LD_LIBRARY_PATH=../../build ./storage_lib_cli info
+
+clean:
+	rm -f $(TARGETS)
+	rm -rf storage-lib-cli-data storage-lib-data
+	rm -f storage_lib.sock daemon.log
+	rm -f downloaded* *.download *.download.* *.roundtrip *.out.*

--- a/tools/libstorage-cpp/README.md
+++ b/tools/libstorage-cpp/README.md
@@ -1,0 +1,114 @@
+# libstorage C++ CLI
+
+This directory contains C++ tools around `library/libstorage.h`.
+
+- `storage_lib_cli`: one-shot command-line wrapper.
+- `storage_lib`: daemon-like libstorage process using Unix socket IPC.
+- `storage_lib_ctl`: small client that sends one command to `storage_lib`.
+
+Build libstorage first from the repository root:
+
+```bash
+make libstorage
+```
+
+If the local compiler hits the known secp256k1 `-march=native` issue on Linux amd64, use:
+
+```bash
+make libstorage NIMFLAGS="-d:disableMarchNative"
+```
+
+Then build the CLI:
+
+```bash
+cd tools/libstorage-cpp
+make
+```
+
+`--timeout-ms 0` means wait indefinitely for libstorage async operations.
+
+Examples:
+
+```bash
+./storage_lib_cli info
+./storage_lib_cli spr
+./storage_lib_cli debug
+./storage_lib_cli list
+./storage_lib_cli upload ./payload.txt
+./storage_lib_cli --local download <cid> ./downloaded.txt
+./storage_lib_cli --local roundtrip ./payload.txt ./payload.roundtrip
+./storage_lib_cli --local repeat-roundtrip ./payload.txt ./payload.out 10
+./storage_lib_cli upload-many ./payload.txt 10
+./storage_lib_cli --local download-many <cid> ./payload.download 10
+```
+
+Options must come before the command. Some libstorage networking diagnostics are
+currently printed directly by the library, so scripts should treat the final line
+as the command result for commands such as `upload`.
+
+Use `make clean` to remove the binary and the default data directory.
+
+## Daemon Mode
+
+Start the libstorage daemon:
+
+```bash
+./storage_lib \
+  --socket ./storage_lib.sock \
+  --data-dir ./storage-lib-data \
+  --log-level WARN \
+  --listen-port 8071 \
+  --disc-port 8091 \
+  --network logos.test \
+  --timeout-ms 0
+```
+
+Send commands with `storage_lib_ctl`:
+
+```bash
+./storage_lib_ctl --socket ./storage_lib.sock info
+./storage_lib_ctl --socket ./storage_lib.sock spr
+./storage_lib_ctl --socket ./storage_lib.sock debug
+./storage_lib_ctl --socket ./storage_lib.sock upload README.md
+./storage_lib_ctl --socket ./storage_lib.sock manifest <cid>
+./storage_lib_ctl --socket ./storage_lib.sock exists <cid>
+./storage_lib_ctl --socket ./storage_lib.sock download <cid> ./downloaded.md true
+./storage_lib_ctl --socket ./storage_lib.sock stream-sink <cid> false
+./storage_lib_ctl --socket ./storage_lib.sock delete <cid>
+./storage_lib_ctl --socket ./storage_lib.sock shutdown
+```
+
+If `--socket` is omitted, `storage_lib_ctl` uses `STORAGE_LIB_SOCKET` when set,
+otherwise `~/.logos/storage/libstorage/storage_lib.sock`.
+
+The IPC request protocol is one whitespace-separated command line per connection.
+Paths with spaces are not supported yet. Responses are one JSON line:
+
+```json
+{"ok":true,"result":"..."}
+```
+
+or:
+
+```json
+{"ok":false,"error":"..."}
+```
+
+## Commands
+
+- `info`: prints version, revision, repo, and peer id.
+- `spr`: prints the node signed peer record.
+- `debug`: prints debug JSON.
+- `connect <peer-id> [addr...]`: connects to a peer using optional multiaddresses.
+- `manifest <cid>`: prints manifest JSON.
+- `delete <cid>`: deletes locally stored content.
+- `fetch <cid>`: fetches content into the local store.
+- `stream-sink <cid> [local]`: streams content and discards data, returning transferred bytes.
+- `shutdown`: cleanly shuts down the node and stops the daemon.
+- `roundtrip <in> <out>`: uploads one file, downloads it, compares bytes, and prints the cid.
+- `repeat-roundtrip <in> <out-prefix> <count>`: repeats roundtrip in one node session.
+- `upload-many <file> <count>`: uploads the same file repeatedly in one node session.
+- `download-many <cid> <out-prefix> <count>`: downloads the same cid repeatedly in one node session.
+
+Options must appear before the command, for example `--local roundtrip`, not
+`roundtrip --local`.

--- a/tools/libstorage-cpp/storage_client.cpp
+++ b/tools/libstorage-cpp/storage_client.cpp
@@ -1,6 +1,7 @@
 #include "storage_client.hpp"
 
 #include <cstdlib>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <utility>
@@ -37,11 +38,15 @@ void shutdownContextBestEffort(
         return;
     }
 
-    StorageResponse resp;
-    if (storage_shutdown(ctx, callback, &resp) != RET_OK) {
+    auto resp = std::make_unique<StorageResponse>();
+    if (storage_shutdown(ctx, callback, resp.get()) != RET_OK) {
         return;
     }
-    resp.wait(timeout);
+
+    if (!resp->wait(timeout)) {
+        // The callback may still fire after timeout; keep userData alive.
+        resp.release();
+    }
 }
 }
 
@@ -108,20 +113,21 @@ StorageClient::StorageClient(std::string configJson, std::chrono::milliseconds t
     : timeout_(timeout) {
     ensureNimRuntime();
 
-    StorageResponse resp;
-    ctx_ = storage_new(configJson.c_str(), callback, &resp);
+    auto resp = std::make_unique<StorageResponse>();
+    ctx_ = storage_new(configJson.c_str(), callback, resp.get());
     if (!ctx_) {
         throw std::runtime_error("storage_new returned null context");
     }
 
-    if (!resp.wait(timeout_)) {
+    if (!resp->wait(timeout_)) {
+        resp.release();
         shutdownContextBestEffort(ctx_, callback, timeout_);
         ctx_ = nullptr;
         throw std::runtime_error("storage_new timed out");
     }
 
-    if (!isOk(resp.status())) {
-        std::string error = resp.data();
+    if (!isOk(resp->status())) {
+        std::string error = resp->data();
         shutdownContextBestEffort(ctx_, callback, timeout_);
         ctx_ = nullptr;
         throw std::runtime_error("storage_new failed: " + error);
@@ -153,8 +159,8 @@ void StorageClient::shutdown() {
         return;
     }
 
-    StorageResponse resp;
-    const int dispatchRet = storage_shutdown(ctx_, callback, &resp);
+    auto resp = std::make_unique<StorageResponse>();
+    const int dispatchRet = storage_shutdown(ctx_, callback, resp.get());
     if (!isOk(dispatchRet)) {
         throw std::runtime_error("storage_shutdown dispatch failed");
     }
@@ -163,12 +169,14 @@ void StorageClient::shutdown() {
     ctx_ = nullptr;
     started_ = false;
 
-    if (!resp.wait(timeout_)) {
+    if (!resp->wait(timeout_)) {
+        // After dispatch, libstorage owns ctx_ and may still call back later.
+        resp.release();
         throw std::runtime_error("storage_shutdown timed out");
     }
 
-    if (!isOk(resp.status())) {
-        throw std::runtime_error("storage_shutdown failed: " + resp.data());
+    if (!isOk(resp->status())) {
+        throw std::runtime_error("storage_shutdown failed: " + resp->data());
     }
 }
 
@@ -294,40 +302,42 @@ size_t StorageClient::streamSink(const std::string& cid, size_t chunkSize, bool 
         return storage_download_init(ctx_, cid.c_str(), chunkSize, local, cb, userData);
     });
 
-    StorageResponse resp;
+    auto resp = std::make_unique<StorageResponse>();
     const int dispatchRet = storage_download_stream(
-        ctx_, cid.c_str(), chunkSize, local, "", callback, &resp);
+        ctx_, cid.c_str(), chunkSize, local, "", callback, resp.get());
     if (!isOk(dispatchRet)) {
         throw std::runtime_error("storage_download_stream dispatch failed");
     }
 
-    if (!resp.wait(timeout_)) {
+    if (!resp->wait(timeout_)) {
+        resp.release();
         throw std::runtime_error("storage_download_stream timed out");
     }
 
-    if (!isOk(resp.status())) {
-        throw std::runtime_error("storage_download_stream failed: " + resp.data());
+    if (!isOk(resp->status())) {
+        throw std::runtime_error("storage_download_stream failed: " + resp->data());
     }
 
-    return resp.progressBytes();
+    return resp->progressBytes();
 }
 
 std::string StorageClient::call(const char* name, const AsyncCall& fn) {
-    StorageResponse resp;
-    const int dispatchRet = fn(callback, &resp);
+    auto resp = std::make_unique<StorageResponse>();
+    const int dispatchRet = fn(callback, resp.get());
     if (!isOk(dispatchRet)) {
         throw std::runtime_error(std::string(name) + " dispatch failed");
     }
 
-    if (!resp.wait(timeout_)) {
+    if (!resp->wait(timeout_)) {
+        resp.release();
         throw std::runtime_error(std::string(name) + " timed out");
     }
 
-    if (!isOk(resp.status())) {
-        throw std::runtime_error(std::string(name) + " failed: " + resp.data());
+    if (!isOk(resp->status())) {
+        throw std::runtime_error(std::string(name) + " failed: " + resp->data());
     }
 
-    return resp.data();
+    return resp->data();
 }
 
 void StorageClient::callback(int callerRet, const char* msg, size_t len, void* userData) {

--- a/tools/libstorage-cpp/storage_client.cpp
+++ b/tools/libstorage-cpp/storage_client.cpp
@@ -1,0 +1,337 @@
+#include "storage_client.hpp"
+
+#include <cstdlib>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+extern "C" {
+extern void libstorageNimMain(void);
+}
+
+namespace {
+void ensureNimRuntime() {
+    static std::once_flag once;
+    std::call_once(once, [] { libstorageNimMain(); });
+}
+
+bool isOk(int ret) {
+    return ret == RET_OK;
+}
+
+std::string takeCString(char* value) {
+    if (!value) {
+        return {};
+    }
+
+    std::string result(value);
+    std::free(value);
+    return result;
+}
+
+void shutdownContextBestEffort(
+    void* ctx,
+    StorageCallback callback,
+    std::chrono::milliseconds timeout) {
+    if (!ctx) {
+        return;
+    }
+
+    StorageResponse resp;
+    if (storage_shutdown(ctx, callback, &resp) != RET_OK) {
+        return;
+    }
+    resp.wait(timeout);
+}
+}
+
+void StorageResponse::setResult(int callerRet, const char* msg, size_t len) {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    if (callerRet == RET_PROGRESS) {
+        progressCount_ += 1;
+        progressBytes_ += len;
+        if (msg && len > 0) {
+            lastProgress_.assign(msg, len);
+        } else {
+            lastProgress_.clear();
+        }
+        return;
+    }
+
+    if (msg && len > 0) {
+        result_.assign(msg, len);
+    } else {
+        result_.clear();
+    }
+
+    status_ = callerRet;
+    done_ = true;
+    cv_.notify_one();
+}
+
+bool StorageResponse::wait(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mtx_);
+    if (timeout.count() == 0) {
+        cv_.wait(lock, [this] { return done_; });
+        return true;
+    }
+    return cv_.wait_for(lock, timeout, [this] { return done_; });
+}
+
+int StorageResponse::status() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return status_;
+}
+
+std::string StorageResponse::data() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return result_;
+}
+
+size_t StorageResponse::progressCount() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return progressCount_;
+}
+
+size_t StorageResponse::progressBytes() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return progressBytes_;
+}
+
+std::string StorageResponse::lastProgress() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return lastProgress_;
+}
+
+StorageClient::StorageClient(std::string configJson, std::chrono::milliseconds timeout)
+    : timeout_(timeout) {
+    ensureNimRuntime();
+
+    StorageResponse resp;
+    ctx_ = storage_new(configJson.c_str(), callback, &resp);
+    if (!ctx_) {
+        throw std::runtime_error("storage_new returned null context");
+    }
+
+    if (!resp.wait(timeout_)) {
+        shutdownContextBestEffort(ctx_, callback, timeout_);
+        ctx_ = nullptr;
+        throw std::runtime_error("storage_new timed out");
+    }
+
+    if (!isOk(resp.status())) {
+        std::string error = resp.data();
+        shutdownContextBestEffort(ctx_, callback, timeout_);
+        ctx_ = nullptr;
+        throw std::runtime_error("storage_new failed: " + error);
+    }
+}
+
+StorageClient::~StorageClient() {
+    if (!ctx_) {
+        return;
+    }
+
+    try {
+        shutdown();
+    } catch (...) {
+        // Destructors must not throw; callers should use explicit shutdown for errors.
+        ctx_ = nullptr;
+    }
+}
+
+void StorageClient::start() {
+    call("storage_start", [this](StorageCallback cb, void* userData) {
+        return storage_start(ctx_, cb, userData);
+    });
+    started_ = true;
+}
+
+void StorageClient::shutdown() {
+    if (!ctx_) {
+        return;
+    }
+
+    StorageResponse resp;
+    const int dispatchRet = storage_shutdown(ctx_, callback, &resp);
+    if (!isOk(dispatchRet)) {
+        throw std::runtime_error("storage_shutdown dispatch failed");
+    }
+
+    // After successful dispatch, libstorage owns ctx_ even if waiting fails.
+    ctx_ = nullptr;
+    started_ = false;
+
+    if (!resp.wait(timeout_)) {
+        throw std::runtime_error("storage_shutdown timed out");
+    }
+
+    if (!isOk(resp.status())) {
+        throw std::runtime_error("storage_shutdown failed: " + resp.data());
+    }
+}
+
+std::string StorageClient::version() const {
+    return takeCString(storage_version(ctx_));
+}
+
+std::string StorageClient::revision() const {
+    return takeCString(storage_revision(ctx_));
+}
+
+std::string StorageClient::repo() {
+    return call("storage_repo", [this](StorageCallback cb, void* userData) {
+        return storage_repo(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::peerId() {
+    return call("storage_peer_id", [this](StorageCallback cb, void* userData) {
+        return storage_peer_id(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::metrics() {
+    return call("storage_get_metrics", [this](StorageCallback cb, void* userData) {
+        return storage_get_metrics(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::debug() {
+    return call("storage_debug", [this](StorageCallback cb, void* userData) {
+        return storage_debug(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::spr() {
+    return call("storage_spr", [this](StorageCallback cb, void* userData) {
+        return storage_spr(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::list() {
+    return call("storage_list", [this](StorageCallback cb, void* userData) {
+        return storage_list(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::space() {
+    return call("storage_space", [this](StorageCallback cb, void* userData) {
+        return storage_space(ctx_, cb, userData);
+    });
+}
+
+std::string StorageClient::manifest(const std::string& cid) {
+    return call("storage_download_manifest", [this, &cid](StorageCallback cb, void* userData) {
+        return storage_download_manifest(ctx_, cid.c_str(), cb, userData);
+    });
+}
+
+std::string StorageClient::exists(const std::string& cid) {
+    return call("storage_exists", [this, &cid](StorageCallback cb, void* userData) {
+        return storage_exists(ctx_, cid.c_str(), cb, userData);
+    });
+}
+
+std::string StorageClient::deleteContent(const std::string& cid) {
+    return call("storage_delete", [this, &cid](StorageCallback cb, void* userData) {
+        return storage_delete(ctx_, cid.c_str(), cb, userData);
+    });
+}
+
+std::string StorageClient::fetch(const std::string& cid) {
+    return call("storage_fetch", [this, &cid](StorageCallback cb, void* userData) {
+        return storage_fetch(ctx_, cid.c_str(), cb, userData);
+    });
+}
+
+std::string StorageClient::connect(
+    const std::string& peerId,
+    const std::vector<std::string>& peerAddresses) {
+    std::vector<const char*> addresses;
+    addresses.reserve(peerAddresses.size());
+    for (const auto& address : peerAddresses) {
+        addresses.push_back(address.c_str());
+    }
+
+    return call("storage_connect", [this, &peerId, &addresses](StorageCallback cb, void* userData) {
+        return storage_connect(ctx_, peerId.c_str(), addresses.data(), addresses.size(), cb, userData);
+    });
+}
+
+std::string StorageClient::uploadFile(const std::string& filepath, size_t chunkSize) {
+    const std::string sessionId = call("storage_upload_init", [this, &filepath, chunkSize](
+                                                             StorageCallback cb,
+                                                             void* userData) {
+        return storage_upload_init(ctx_, filepath.c_str(), chunkSize, cb, userData);
+    });
+
+    return call("storage_upload_file", [this, &sessionId](StorageCallback cb, void* userData) {
+        return storage_upload_file(ctx_, sessionId.c_str(), cb, userData);
+    });
+}
+
+std::string StorageClient::downloadFile(
+    const std::string& cid,
+    const std::string& outputPath,
+    size_t chunkSize,
+    bool local) {
+    call("storage_download_init", [this, &cid, chunkSize, local](StorageCallback cb, void* userData) {
+        return storage_download_init(ctx_, cid.c_str(), chunkSize, local, cb, userData);
+    });
+
+    return call("storage_download_stream", [this, &cid, &outputPath, chunkSize, local](
+                                               StorageCallback cb,
+                                               void* userData) {
+        return storage_download_stream(
+            ctx_, cid.c_str(), chunkSize, local, outputPath.c_str(), cb, userData);
+    });
+}
+
+size_t StorageClient::streamSink(const std::string& cid, size_t chunkSize, bool local) {
+    call("storage_download_init", [this, &cid, chunkSize, local](StorageCallback cb, void* userData) {
+        return storage_download_init(ctx_, cid.c_str(), chunkSize, local, cb, userData);
+    });
+
+    StorageResponse resp;
+    const int dispatchRet = storage_download_stream(
+        ctx_, cid.c_str(), chunkSize, local, "", callback, &resp);
+    if (!isOk(dispatchRet)) {
+        throw std::runtime_error("storage_download_stream dispatch failed");
+    }
+
+    if (!resp.wait(timeout_)) {
+        throw std::runtime_error("storage_download_stream timed out");
+    }
+
+    if (!isOk(resp.status())) {
+        throw std::runtime_error("storage_download_stream failed: " + resp.data());
+    }
+
+    return resp.progressBytes();
+}
+
+std::string StorageClient::call(const char* name, const AsyncCall& fn) {
+    StorageResponse resp;
+    const int dispatchRet = fn(callback, &resp);
+    if (!isOk(dispatchRet)) {
+        throw std::runtime_error(std::string(name) + " dispatch failed");
+    }
+
+    if (!resp.wait(timeout_)) {
+        throw std::runtime_error(std::string(name) + " timed out");
+    }
+
+    if (!isOk(resp.status())) {
+        throw std::runtime_error(std::string(name) + " failed: " + resp.data());
+    }
+
+    return resp.data();
+}
+
+void StorageClient::callback(int callerRet, const char* msg, size_t len, void* userData) {
+    if (auto* resp = static_cast<StorageResponse*>(userData)) {
+        resp->setResult(callerRet, msg, len);
+    }
+}

--- a/tools/libstorage-cpp/storage_client.hpp
+++ b/tools/libstorage-cpp/storage_client.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "libstorage.h"
+}
+
+class StorageResponse {
+public:
+    StorageResponse() = default;
+    StorageResponse(const StorageResponse&) = delete;
+    StorageResponse& operator=(const StorageResponse&) = delete;
+
+    void setResult(int callerRet, const char* msg, size_t len);
+    bool wait(std::chrono::milliseconds timeout = std::chrono::seconds(60));
+
+    int status() const;
+    std::string data() const;
+    size_t progressCount() const;
+    size_t progressBytes() const;
+    std::string lastProgress() const;
+
+private:
+    mutable std::mutex mtx_;
+    std::condition_variable cv_;
+    bool done_ = false;
+    int status_ = -1;
+    std::string result_;
+    size_t progressCount_ = 0;
+    size_t progressBytes_ = 0;
+    std::string lastProgress_;
+};
+
+class StorageClient {
+public:
+    explicit StorageClient(
+        std::string configJson,
+        std::chrono::milliseconds timeout = std::chrono::seconds(120));
+    StorageClient(const StorageClient&) = delete;
+    StorageClient& operator=(const StorageClient&) = delete;
+    ~StorageClient();
+
+    void start();
+    void shutdown();
+
+    std::string version() const;
+    std::string revision() const;
+    std::string repo();
+    std::string peerId();
+    std::string metrics();
+    std::string debug();
+    std::string spr();
+    std::string list();
+    std::string space();
+    std::string manifest(const std::string& cid);
+    std::string exists(const std::string& cid);
+    std::string deleteContent(const std::string& cid);
+    std::string fetch(const std::string& cid);
+    std::string connect(const std::string& peerId, const std::vector<std::string>& peerAddresses);
+    std::string uploadFile(const std::string& filepath, size_t chunkSize);
+    std::string downloadFile(
+        const std::string& cid,
+        const std::string& outputPath,
+        size_t chunkSize,
+        bool local);
+    size_t streamSink(const std::string& cid, size_t chunkSize, bool local);
+
+private:
+    using AsyncCall = std::function<int(StorageCallback, void*)>;
+
+    std::string call(const char* name, const AsyncCall& fn);
+    static void callback(int callerRet, const char* msg, size_t len, void* userData);
+
+    void* ctx_ = nullptr;
+    std::chrono::milliseconds timeout_;
+    bool started_ = false;
+};

--- a/tools/libstorage-cpp/storage_lib.cpp
+++ b/tools/libstorage-cpp/storage_lib.cpp
@@ -1,9 +1,11 @@
 #include "storage_client.hpp"
 
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <csignal>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>

--- a/tools/libstorage-cpp/storage_lib.cpp
+++ b/tools/libstorage-cpp/storage_lib.cpp
@@ -1,0 +1,350 @@
+#include "storage_client.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+constexpr size_t DefaultChunkSize = 64 * 1024;
+
+struct Options {
+    std::string socketPath;
+    std::string dataDir;
+    std::string logLevel = "WARN";
+    std::string network = "logos.test";
+    uint16_t listenPort = 8071;
+    uint16_t discPort = 8091;
+    size_t chunkSize = DefaultChunkSize;
+    std::chrono::milliseconds timeout = std::chrono::seconds(120);
+};
+
+std::atomic<bool> g_stop{false};
+int g_serverFd = -1;
+
+std::string homeDir() {
+    const char* home = std::getenv("HOME");
+    if (!home || std::strlen(home) == 0) {
+        throw std::runtime_error("HOME is not set");
+    }
+    return home;
+}
+
+std::string defaultSocketPath() {
+    return homeDir() + "/.logos/storage/libstorage/storage_lib.sock";
+}
+
+std::string defaultDataDir() {
+    return homeDir() + "/.logos/storage/libstorage/node";
+}
+
+std::string jsonEscape(const std::string& value) {
+    std::string out;
+    out.reserve(value.size() + 8);
+    for (char ch : value) {
+        switch (ch) {
+        case '\\': out += "\\\\"; break;
+        case '"': out += "\\\""; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default: out += ch; break;
+        }
+    }
+    return out;
+}
+
+std::string okResponse(const std::string& result) {
+    return "{\"ok\":true,\"result\":\"" + jsonEscape(result) + "\"}\n";
+}
+
+std::string errorResponse(const std::string& error) {
+    return "{\"ok\":false,\"error\":\"" + jsonEscape(error) + "\"}\n";
+}
+
+std::string configJson(const Options& options) {
+    return "{\"log-level\":\"" + jsonEscape(options.logLevel) + "\"," +
+           "\"data-dir\":\"" + jsonEscape(options.dataDir) + "\"," +
+           "\"network\":\"" + jsonEscape(options.network) + "\"," +
+           "\"listen-port\":" + std::to_string(options.listenPort) + "," +
+           "\"disc-port\":" + std::to_string(options.discPort) + "," +
+           "\"metrics\":false}";
+}
+
+size_t parseSize(const std::string& value) {
+    size_t pos = 0;
+    const auto parsed = std::stoull(value, &pos);
+    if (pos != value.size()) {
+        throw std::runtime_error("invalid size: " + value);
+    }
+    return static_cast<size_t>(parsed);
+}
+
+uint16_t parsePort(const std::string& value) {
+    const size_t parsed = parseSize(value);
+    if (parsed == 0 || parsed > 65535) {
+        throw std::runtime_error("invalid port: " + value);
+    }
+    return static_cast<uint16_t>(parsed);
+}
+
+bool parseBool(const std::string& value) {
+    if (value == "true" || value == "1" || value == "yes") {
+        return true;
+    }
+    if (value == "false" || value == "0" || value == "no") {
+        return false;
+    }
+    throw std::runtime_error("invalid boolean: " + value);
+}
+
+std::vector<std::string> splitLine(const std::string& line) {
+    std::istringstream input(line);
+    std::vector<std::string> parts;
+    std::string part;
+    while (input >> part) {
+        parts.push_back(part);
+    }
+    return parts;
+}
+
+void printUsage() {
+    std::cout <<
+        "Usage:\n"
+        "  storage_lib [options]\n\n"
+        "Options:\n"
+        "  --socket <path>       Unix socket path\n"
+        "  --data-dir <path>     Node data directory\n"
+        "  --log-level <level>   TRACE, DEBUG, INFO, NOTICE, WARN, ERROR, FATAL\n"
+        "  --listen-port <port>  Local libp2p TCP listen port (default: 8071)\n"
+        "  --disc-port <port>    Local discovery UDP port (default: 8091)\n"
+        "  --network <name>      Network preset (default: logos.test)\n"
+        "  --chunk-size <bytes>  Upload/download chunk size (default: 65536)\n"
+        "  --timeout-ms <ms>     Async operation timeout, 0 waits forever (default: 120000)\n"
+        "  -h, --help            Show this help\n";
+}
+
+Options parseArgs(int argc, char** argv) {
+    Options options;
+    options.socketPath = defaultSocketPath();
+    options.dataDir = defaultDataDir();
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            printUsage();
+            std::exit(0);
+        } else if (arg == "--socket" && i + 1 < argc) {
+            options.socketPath = argv[++i];
+        } else if (arg == "--data-dir" && i + 1 < argc) {
+            options.dataDir = argv[++i];
+        } else if (arg == "--log-level" && i + 1 < argc) {
+            options.logLevel = argv[++i];
+        } else if (arg == "--listen-port" && i + 1 < argc) {
+            options.listenPort = parsePort(argv[++i]);
+        } else if (arg == "--disc-port" && i + 1 < argc) {
+            options.discPort = parsePort(argv[++i]);
+        } else if (arg == "--network" && i + 1 < argc) {
+            options.network = argv[++i];
+        } else if (arg == "--chunk-size" && i + 1 < argc) {
+            options.chunkSize = parseSize(argv[++i]);
+        } else if (arg == "--timeout-ms" && i + 1 < argc) {
+            options.timeout = std::chrono::milliseconds(parseSize(argv[++i]));
+        } else {
+            throw std::runtime_error("unknown or incomplete option: " + arg);
+        }
+    }
+
+    return options;
+}
+
+std::string infoResult(StorageClient& client) {
+    return "{\"version\":\"" + jsonEscape(client.version()) + "\"," +
+           "\"revision\":\"" + jsonEscape(client.revision()) + "\"," +
+           "\"repo\":\"" + jsonEscape(client.repo()) + "\"," +
+           "\"peer_id\":\"" + jsonEscape(client.peerId()) + "\"}";
+}
+
+std::string dispatch(
+    StorageClient& client,
+    const Options& options,
+    const std::string& line) {
+    const auto parts = splitLine(line);
+    if (parts.empty()) {
+        throw std::runtime_error("empty command");
+    }
+
+    const auto& cmd = parts[0];
+
+    if (cmd == "shutdown" || cmd == "destroy") {
+        client.shutdown();
+        g_stop = true;
+        return "shutdown complete";
+    }
+
+    if (cmd == "info") return infoResult(client);
+    if (cmd == "version") return client.version();
+    if (cmd == "revision") return client.revision();
+    if (cmd == "repo") return client.repo();
+    if (cmd == "peer-id" || cmd == "peerid") return client.peerId();
+    if (cmd == "spr") return client.spr();
+    if (cmd == "debug") return client.debug();
+    if (cmd == "metrics") return client.metrics();
+    if (cmd == "list") return client.list();
+    if (cmd == "space") return client.space();
+
+    if (cmd == "upload") {
+        if (parts.size() != 2) throw std::runtime_error("usage: upload <file>");
+        return client.uploadFile(parts[1], options.chunkSize);
+    }
+    if (cmd == "download") {
+        if (parts.size() < 3 || parts.size() > 4) {
+            throw std::runtime_error("usage: download <cid> <file> [local]");
+        }
+        const bool local = parts.size() == 4 ? parseBool(parts[3]) : false;
+        return client.downloadFile(parts[1], parts[2], options.chunkSize, local);
+    }
+    if (cmd == "stream-sink") {
+        if (parts.size() < 2 || parts.size() > 3) {
+            throw std::runtime_error("usage: stream-sink <cid> [local]");
+        }
+        const bool local = parts.size() == 3 ? parseBool(parts[2]) : false;
+        return std::to_string(client.streamSink(parts[1], options.chunkSize, local));
+    }
+    if (cmd == "exists") {
+        if (parts.size() != 2) throw std::runtime_error("usage: exists <cid>");
+        return client.exists(parts[1]);
+    }
+    if (cmd == "delete") {
+        if (parts.size() != 2) throw std::runtime_error("usage: delete <cid>");
+        return client.deleteContent(parts[1]);
+    }
+    if (cmd == "fetch") {
+        if (parts.size() != 2) throw std::runtime_error("usage: fetch <cid>");
+        return client.fetch(parts[1]);
+    }
+    if (cmd == "manifest") {
+        if (parts.size() != 2) throw std::runtime_error("usage: manifest <cid>");
+        return client.manifest(parts[1]);
+    }
+    if (cmd == "connect") {
+        if (parts.size() < 2) throw std::runtime_error("usage: connect <peer-id> [addr...]");
+        std::vector<std::string> addresses(parts.begin() + 2, parts.end());
+        return client.connect(parts[1], addresses);
+    }
+    throw std::runtime_error("unknown command: " + cmd);
+}
+
+std::string readLine(int fd) {
+    std::string line;
+    char ch = '\0';
+    while (true) {
+        ssize_t n = ::read(fd, &ch, 1);
+        if (n == 0) break;
+        if (n < 0) throw std::runtime_error(std::string("read failed: ") + std::strerror(errno));
+        if (ch == '\n') break;
+        line += ch;
+    }
+    return line;
+}
+
+void writeAll(int fd, const std::string& data) {
+    const char* ptr = data.data();
+    size_t left = data.size();
+    while (left > 0) {
+        ssize_t n = ::write(fd, ptr, left);
+        if (n < 0) throw std::runtime_error(std::string("write failed: ") + std::strerror(errno));
+        ptr += n;
+        left -= static_cast<size_t>(n);
+    }
+}
+
+int createServerSocket(const std::string& socketPath) {
+    if (socketPath.size() >= sizeof(sockaddr_un::sun_path)) {
+        throw std::runtime_error("socket path is too long: " + socketPath);
+    }
+
+    std::filesystem::create_directories(std::filesystem::path(socketPath).parent_path());
+    ::unlink(socketPath.c_str());
+
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) throw std::runtime_error(std::string("socket failed: ") + std::strerror(errno));
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(fd);
+        throw std::runtime_error(std::string("bind failed: ") + std::strerror(errno));
+    }
+    if (::listen(fd, 16) < 0) {
+        ::close(fd);
+        throw std::runtime_error(std::string("listen failed: ") + std::strerror(errno));
+    }
+
+    return fd;
+}
+
+void handleSignal(int) {
+    g_stop = true;
+    if (g_serverFd >= 0) {
+        ::close(g_serverFd);
+        g_serverFd = -1;
+    }
+}
+}
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parseArgs(argc, argv);
+
+        std::signal(SIGINT, handleSignal);
+        std::signal(SIGTERM, handleSignal);
+
+        StorageClient client(configJson(options), options.timeout);
+        client.start();
+
+        g_serverFd = createServerSocket(options.socketPath);
+        std::cout << "storage_lib listening on " << options.socketPath << "\n";
+        std::cout.flush();
+
+        while (!g_stop) {
+            int clientFd = ::accept(g_serverFd, nullptr, nullptr);
+            if (clientFd < 0) {
+                if (g_stop) break;
+                if (errno == EINTR) continue;
+                throw std::runtime_error(std::string("accept failed: ") + std::strerror(errno));
+            }
+
+            try {
+                const std::string line = readLine(clientFd);
+                writeAll(clientFd, okResponse(dispatch(client, options, line)));
+            } catch (const std::exception& err) {
+                writeAll(clientFd, errorResponse(err.what()));
+            }
+            ::close(clientFd);
+        }
+
+        if (g_serverFd >= 0) {
+            ::close(g_serverFd);
+            g_serverFd = -1;
+        }
+        ::unlink(options.socketPath.c_str());
+        return 0;
+    } catch (const std::exception& err) {
+        std::cerr << "error: " << err.what() << "\n";
+        return 1;
+    }
+}

--- a/tools/libstorage-cpp/storage_lib.cpp
+++ b/tools/libstorage-cpp/storage_lib.cpp
@@ -190,8 +190,8 @@ std::string dispatch(
     const auto& cmd = parts[0];
 
     if (cmd == "shutdown" || cmd == "destroy") {
-        client.shutdown();
         g_stop = true;
+        client.shutdown();
         return "shutdown complete";
     }
 

--- a/tools/libstorage-cpp/storage_lib_cli.cpp
+++ b/tools/libstorage-cpp/storage_lib_cli.cpp
@@ -1,0 +1,319 @@
+#include "storage_client.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+constexpr size_t DefaultChunkSize = 64 * 1024;
+
+struct Options {
+    std::string dataDir = "./storage-lib-cli-data";
+    std::string logLevel = "WARN";
+    size_t chunkSize = DefaultChunkSize;
+    std::chrono::milliseconds timeout = std::chrono::seconds(120);
+    bool local = false;
+    bool noStart = false;
+    std::string command;
+    std::vector<std::string> args;
+};
+
+std::string jsonEscape(const std::string& value) {
+    std::string out;
+    out.reserve(value.size() + 8);
+    for (char ch : value) {
+        switch (ch) {
+        case '\\':
+            out += "\\\\";
+            break;
+        case '"':
+            out += "\\\"";
+            break;
+        case '\n':
+            out += "\\n";
+            break;
+        case '\r':
+            out += "\\r";
+            break;
+        case '\t':
+            out += "\\t";
+            break;
+        default:
+            out += ch;
+            break;
+        }
+    }
+    return out;
+}
+
+std::string configJson(const Options& options) {
+    return "{\"log-level\":\"" + jsonEscape(options.logLevel) + "\"," +
+           "\"data-dir\":\"" + jsonEscape(options.dataDir) + "\"," +
+           "\"metrics\":false}";
+}
+
+void printUsage() {
+    std::cout <<
+        "Usage:\n"
+        "  storage_lib_cli [options] <command> [args]\n\n"
+        "Options:\n"
+        "  --data-dir <path>      Node data directory (default: ./storage-lib-cli-data)\n"
+        "  --log-level <level>    TRACE, DEBUG, INFO, NOTICE, WARN, ERROR, FATAL\n"
+        "  --chunk-size <bytes>   Upload/download chunk size (default: 65536)\n"
+        "  --timeout-ms <ms>      Async operation timeout (default: 120000)\n"
+        "  --local                Download from local store only\n"
+        "  --no-start             Create context but do not start node before command\n\n"
+        "Commands:\n"
+        "  info                   Print version, revision, repo, and peer id\n"
+        "  version                Print storage version\n"
+        "  revision               Print storage revision\n"
+        "  repo                   Print configured repo/data-dir\n"
+        "  peer-id                Print node peer id\n"
+        "  spr                    Print node signed peer record\n"
+        "  debug                  Print node debug JSON\n"
+        "  connect <peer-id> [addr...]\n"
+        "                         Connect to peer using optional multiaddresses\n"
+        "  metrics                Print metrics JSON\n"
+        "  list                   Print local manifest list JSON\n"
+        "  space                  Print storage space JSON\n"
+        "  manifest <cid>         Print manifest JSON\n"
+        "  exists <cid>           Check whether cid exists locally\n"
+        "  delete <cid>           Delete locally stored content\n"
+        "  fetch <cid>            Fetch content into the local store\n"
+        "  upload <file>          Upload a file and print its cid\n"
+        "  download <cid> <file>  Download cid into file\n"
+        "  stream-sink <cid>      Stream cid and discard data; prints bytes\n"
+        "  roundtrip <in> <out>   Upload, download, compare, and print cid\n"
+        "  repeat-roundtrip <in> <out-prefix> <count>\n"
+        "                         Repeat roundtrip in one node session\n"
+        "  upload-many <file> <count>\n"
+        "                         Upload same file repeatedly in one node session\n"
+        "  download-many <cid> <out-prefix> <count>\n"
+        "                         Download same cid repeatedly in one node session\n";
+}
+
+size_t parseSize(const std::string& value) {
+    size_t pos = 0;
+    const auto parsed = std::stoull(value, &pos);
+    if (pos != value.size()) {
+        throw std::runtime_error("invalid size: " + value);
+    }
+    return static_cast<size_t>(parsed);
+}
+
+int parseCount(const std::string& value) {
+    const size_t parsed = parseSize(value);
+    if (parsed == 0) {
+        throw std::runtime_error("count must be greater than zero");
+    }
+    return static_cast<int>(parsed);
+}
+
+Options parseArgs(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            options.command = "help";
+            return options;
+        }
+        if (arg == "--data-dir" && i + 1 < argc) {
+            options.dataDir = argv[++i];
+        } else if (arg == "--log-level" && i + 1 < argc) {
+            options.logLevel = argv[++i];
+        } else if (arg == "--chunk-size" && i + 1 < argc) {
+            options.chunkSize = parseSize(argv[++i]);
+        } else if (arg == "--timeout-ms" && i + 1 < argc) {
+            options.timeout = std::chrono::milliseconds(parseSize(argv[++i]));
+        } else if (arg == "--local") {
+            options.local = true;
+        } else if (arg == "--no-start") {
+            options.noStart = true;
+        } else if (!arg.empty() && arg[0] == '-') {
+            throw std::runtime_error("unknown option: " + arg);
+        } else {
+            options.command = arg;
+            for (++i; i < argc; ++i) {
+                options.args.emplace_back(argv[i]);
+            }
+            return options;
+        }
+    }
+
+    options.command = "help";
+    return options;
+}
+
+void requireArgCount(const Options& options, size_t count) {
+    if (options.args.size() != count) {
+        throw std::runtime_error("command '" + options.command + "' expects " +
+                                 std::to_string(count) + " argument(s)");
+    }
+}
+
+bool filesEqual(const std::string& leftPath, const std::string& rightPath) {
+    std::ifstream left(leftPath, std::ios::binary);
+    std::ifstream right(rightPath, std::ios::binary);
+    if (!left || !right) {
+        return false;
+    }
+
+    constexpr size_t BufferSize = 64 * 1024;
+    std::vector<char> leftBuffer(BufferSize);
+    std::vector<char> rightBuffer(BufferSize);
+    while (left && right) {
+        left.read(leftBuffer.data(), leftBuffer.size());
+        right.read(rightBuffer.data(), rightBuffer.size());
+        if (left.gcount() != right.gcount()) {
+            return false;
+        }
+        if (!std::equal(
+                leftBuffer.begin(),
+                leftBuffer.begin() + left.gcount(),
+                rightBuffer.begin())) {
+            return false;
+        }
+    }
+
+    return left.eof() && right.eof();
+}
+
+std::string indexedPath(const std::string& prefix, int index) {
+    return prefix + "." + std::to_string(index);
+}
+
+std::string roundtrip(
+    StorageClient& client,
+    const Options& options,
+    const std::string& inputPath,
+    const std::string& outputPath) {
+    const std::string cid = client.uploadFile(inputPath, options.chunkSize);
+    client.downloadFile(cid, outputPath, options.chunkSize, options.local);
+    if (!filesEqual(inputPath, outputPath)) {
+        throw std::runtime_error("roundtrip byte comparison failed for cid: " + cid);
+    }
+    return cid;
+}
+}
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parseArgs(argc, argv);
+        if (options.command == "help") {
+            printUsage();
+            return 0;
+        }
+
+        StorageClient client(configJson(options), options.timeout);
+        if (!options.noStart) {
+            client.start();
+        }
+
+        if (options.command == "info") {
+            requireArgCount(options, 0);
+            std::cout << "version: " << client.version() << "\n";
+            std::cout << "revision: " << client.revision() << "\n";
+            std::cout << "repo: " << client.repo() << "\n";
+            std::cout << "peer_id: " << client.peerId() << "\n";
+        } else if (options.command == "version") {
+            requireArgCount(options, 0);
+            std::cout << client.version() << "\n";
+        } else if (options.command == "revision") {
+            requireArgCount(options, 0);
+            std::cout << client.revision() << "\n";
+        } else if (options.command == "repo") {
+            requireArgCount(options, 0);
+            std::cout << client.repo() << "\n";
+        } else if (options.command == "peer-id") {
+            requireArgCount(options, 0);
+            std::cout << client.peerId() << "\n";
+        } else if (options.command == "spr") {
+            requireArgCount(options, 0);
+            std::cout << client.spr() << "\n";
+        } else if (options.command == "debug") {
+            requireArgCount(options, 0);
+            std::cout << client.debug() << "\n";
+        } else if (options.command == "connect") {
+            if (options.args.empty()) {
+                throw std::runtime_error("command 'connect' expects at least 1 argument");
+            }
+            std::vector<std::string> addresses(options.args.begin() + 1, options.args.end());
+            std::cout << client.connect(options.args[0], addresses) << "\n";
+        } else if (options.command == "metrics") {
+            requireArgCount(options, 0);
+            std::cout << client.metrics() << "\n";
+        } else if (options.command == "list") {
+            requireArgCount(options, 0);
+            std::cout << client.list() << "\n";
+        } else if (options.command == "space") {
+            requireArgCount(options, 0);
+            std::cout << client.space() << "\n";
+        } else if (options.command == "manifest") {
+            requireArgCount(options, 1);
+            std::cout << client.manifest(options.args[0]) << "\n";
+        } else if (options.command == "exists") {
+            requireArgCount(options, 1);
+            std::cout << client.exists(options.args[0]) << "\n";
+        } else if (options.command == "delete") {
+            requireArgCount(options, 1);
+            std::cout << client.deleteContent(options.args[0]) << "\n";
+        } else if (options.command == "fetch") {
+            requireArgCount(options, 1);
+            std::cout << client.fetch(options.args[0]) << "\n";
+        } else if (options.command == "upload") {
+            requireArgCount(options, 1);
+            std::cout << client.uploadFile(options.args[0], options.chunkSize) << "\n";
+        } else if (options.command == "download") {
+            requireArgCount(options, 2);
+            std::cout << client.downloadFile(
+                             options.args[0], options.args[1], options.chunkSize, options.local)
+                      << "\n";
+        } else if (options.command == "stream-sink") {
+            requireArgCount(options, 1);
+            std::cout << client.streamSink(options.args[0], options.chunkSize, options.local) << "\n";
+        } else if (options.command == "roundtrip") {
+            requireArgCount(options, 2);
+            std::cout << roundtrip(client, options, options.args[0], options.args[1]) << "\n";
+        } else if (options.command == "repeat-roundtrip") {
+            requireArgCount(options, 3);
+            const int count = parseCount(options.args[2]);
+            std::string lastCid;
+            for (int i = 1; i <= count; ++i) {
+                lastCid = roundtrip(client, options, options.args[0], indexedPath(options.args[1], i));
+                std::cout << i << " " << lastCid << "\n";
+            }
+            std::cout << "completed repeat-roundtrip count=" << count << " last_cid=" << lastCid
+                      << "\n";
+        } else if (options.command == "upload-many") {
+            requireArgCount(options, 2);
+            const int count = parseCount(options.args[1]);
+            std::string lastCid;
+            for (int i = 1; i <= count; ++i) {
+                lastCid = client.uploadFile(options.args[0], options.chunkSize);
+                std::cout << i << " " << lastCid << "\n";
+            }
+            std::cout << "completed upload-many count=" << count << " last_cid=" << lastCid << "\n";
+        } else if (options.command == "download-many") {
+            requireArgCount(options, 3);
+            const int count = parseCount(options.args[2]);
+            for (int i = 1; i <= count; ++i) {
+                const std::string outputPath = indexedPath(options.args[1], i);
+                client.downloadFile(options.args[0], outputPath, options.chunkSize, options.local);
+                std::cout << i << " " << outputPath << "\n";
+            }
+            std::cout << "completed download-many count=" << count << "\n";
+        } else {
+            throw std::runtime_error("unknown command: " + options.command);
+        }
+
+        return 0;
+    } catch (const std::exception& err) {
+        std::cerr << "error: " << err.what() << "\n";
+        return 1;
+    }
+}

--- a/tools/libstorage-cpp/storage_lib_ctl.cpp
+++ b/tools/libstorage-cpp/storage_lib_ctl.cpp
@@ -134,7 +134,8 @@ int main(int argc, char** argv) {
         ::close(fd);
 
         std::cout << response;
-        return response.find("\"ok\":false") == std::string::npos ? 0 : 1;
+        if (response.empty()) return 1;
+        return response.rfind("{\"ok\":false", 0) == 0 ? 1 : 0;
     } catch (const std::exception& err) {
         std::cerr << "error: " << err.what() << "\n";
         return 1;

--- a/tools/libstorage-cpp/storage_lib_ctl.cpp
+++ b/tools/libstorage-cpp/storage_lib_ctl.cpp
@@ -1,0 +1,142 @@
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+std::string homeDir() {
+    const char* home = std::getenv("HOME");
+    if (!home || std::strlen(home) == 0) {
+        throw std::runtime_error("HOME is not set");
+    }
+    return home;
+}
+
+std::string defaultSocketPath() {
+    const char* fromEnv = std::getenv("STORAGE_LIB_SOCKET");
+    if (fromEnv && std::strlen(fromEnv) > 0) {
+        return fromEnv;
+    }
+    return homeDir() + "/.logos/storage/libstorage/storage_lib.sock";
+}
+
+void printUsage() {
+    std::cout <<
+        "Usage:\n"
+        "  storage_lib_ctl [--socket <path>] <command> [args]\n\n"
+        "Commands are sent as one line to storage_lib. Examples:\n"
+        "  storage_lib_ctl info\n"
+        "  storage_lib_ctl upload README.md\n"
+        "  storage_lib_ctl download <cid> ./out true\n"
+        "  storage_lib_ctl shutdown\n"
+        "  storage_lib_ctl destroy\n";
+}
+
+struct Options {
+    std::string socketPath;
+    std::vector<std::string> command;
+};
+
+Options parseArgs(int argc, char** argv) {
+    Options options;
+    options.socketPath = defaultSocketPath();
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            printUsage();
+            std::exit(0);
+        } else if (arg == "--socket" && i + 1 < argc) {
+            options.socketPath = argv[++i];
+        } else if (!arg.empty() && arg[0] == '-') {
+            throw std::runtime_error("unknown or incomplete option: " + arg);
+        } else {
+            for (; i < argc; ++i) {
+                options.command.emplace_back(argv[i]);
+            }
+            break;
+        }
+    }
+
+    if (options.command.empty()) {
+        throw std::runtime_error("missing command");
+    }
+    return options;
+}
+
+std::string commandLine(const std::vector<std::string>& command) {
+    std::string line;
+    for (size_t i = 0; i < command.size(); ++i) {
+        if (i > 0) line += ' ';
+        line += command[i];
+    }
+    line += '\n';
+    return line;
+}
+
+int connectSocket(const std::string& socketPath) {
+    if (socketPath.size() >= sizeof(sockaddr_un::sun_path)) {
+        throw std::runtime_error("socket path is too long: " + socketPath);
+    }
+
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) throw std::runtime_error(std::string("socket failed: ") + std::strerror(errno));
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(fd);
+        throw std::runtime_error(std::string("connect failed: ") + std::strerror(errno));
+    }
+    return fd;
+}
+
+void writeAll(int fd, const std::string& data) {
+    const char* ptr = data.data();
+    size_t left = data.size();
+    while (left > 0) {
+        ssize_t n = ::write(fd, ptr, left);
+        if (n < 0) throw std::runtime_error(std::string("write failed: ") + std::strerror(errno));
+        ptr += n;
+        left -= static_cast<size_t>(n);
+    }
+}
+
+std::string readAll(int fd) {
+    std::string out;
+    char buffer[4096];
+    while (true) {
+        ssize_t n = ::read(fd, buffer, sizeof(buffer));
+        if (n == 0) break;
+        if (n < 0) throw std::runtime_error(std::string("read failed: ") + std::strerror(errno));
+        out.append(buffer, static_cast<size_t>(n));
+    }
+    return out;
+}
+}
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parseArgs(argc, argv);
+        int fd = connectSocket(options.socketPath);
+        writeAll(fd, commandLine(options.command));
+        ::shutdown(fd, SHUT_WR);
+        const std::string response = readAll(fd);
+        ::close(fd);
+
+        std::cout << response;
+        return response.find("\"ok\":false") == std::string::npos ? 0 : 1;
+    } catch (const std::exception& err) {
+        std::cerr << "error: " << err.what() << "\n";
+        return 1;
+    }
+}

--- a/tools/storage-test/AGENTS.md
+++ b/tools/storage-test/AGENTS.md
@@ -1,0 +1,201 @@
+# Storage Test Tooling Notes
+
+This folder contains local/Linode test helpers for comparing the standard REST node with the libstorage C++ daemon target.
+
+## Current Layout
+
+- `start-local-node.sh`: foreground launcher for either the standard storage binary or the libstorage daemon.
+- `storage-test.sh`: target-first test helper for local REST, remote REST, and libstorage daemon targets.
+- `README.md`: operator-facing usage guide.
+- `SETUP_STORAGE_NODE.md`: Linode/headless node setup recipe.
+
+Related C++ libstorage tools live in `../libstorage-cpp/`:
+
+- `storage_client.hpp` / `storage_client.cpp`: shared C++ wrapper around `library/libstorage.h`.
+- `storage_lib_cli`: one-shot libstorage CLI.
+- `storage_lib`: daemon-like libstorage process using Unix socket IPC.
+- `storage_lib_ctl`: control client that sends one command to `storage_lib`.
+
+## Build Notes
+
+On the current AMD Ryzen AI 9 HX 370 machine, local Nim builds should use:
+
+```bash
+make NIMFLAGS="-d:disableMarchNative"
+make libstorage NIMFLAGS="-d:disableMarchNative"
+```
+
+This avoids the known GCC/secp256k1 x86_64 asm failure caused by `-march=native`.
+
+Build libstorage C++ tools with:
+
+```bash
+cd tools/libstorage-cpp
+make
+```
+
+Generated C++ binaries, daemon data dirs, sockets, logs, and report files are ignored/cleaned by the relevant Makefile or `.gitignore` entries.
+
+## Launcher Model
+
+`start-local-node.sh` supports two clients:
+
+```bash
+tools/storage-test/start-local-node.sh --client storage
+tools/storage-test/start-local-node.sh --client lib
+```
+
+Shared config between both clients:
+
+- `--data-dir`
+- `--log-level`
+- `--listen-port`
+- `--disc-port`
+- `--network`
+
+Standard storage-only config:
+
+- `--binary`
+- `--api-bindaddr`
+- `--api-port`
+
+Lib daemon-only config:
+
+- `--lib-binary`
+- `--socket`
+- `--timeout-ms`
+- `--chunk-size`
+
+Default data dirs intentionally differ to avoid datastore locking conflicts:
+
+- Standard REST node: `~/.logos/storage/local-node`
+- Libstorage daemon: `~/.logos/storage/libstorage/node`
+
+## storage-test.sh Command Model
+
+The script is target-first. Do not reintroduce command-first compatibility unless explicitly requested.
+
+```bash
+tools/storage-test/storage-test.sh <target> <command> [args]
+```
+
+Targets:
+
+- `local`: local standard REST node at `127.0.0.1:${LOCAL_API_PORT}`.
+- `remote`: Linode REST node through SSH tunnel at `127.0.0.1:${REMOTE_API_PORT}`.
+- `lib`: local `storage_lib` daemon through `storage_lib_ctl` and Unix socket.
+
+Global commands remain targetless:
+
+- `help`
+- `tunnel start|stop|status`
+- `make-file`
+- `last-cid [target]`
+
+Common target commands:
+
+- `upload <file>`
+- `upload-random <size> [--keep]`
+- `download <cid> <output-file> [--local]`
+- `fetch <cid> [--wait]`
+- `stream-sink <cid> [--local]`
+- `list`
+- `delete <cid>`
+- `delete-all --yes`
+- `exists <cid>`
+- `space`
+- `peerid`
+- `test`
+
+Lib-only target commands:
+
+- `spr`
+- `debug`
+- `peers`
+- `manifest <cid>`
+- `connect <peer-id> [addr...]`
+
+## Lib Target Details
+
+`storage-test.sh lib` invokes `storage_lib_ctl`. Socket resolution for `storage_lib_ctl` is:
+
+1. `--socket <path>`
+2. `STORAGE_LIB_SOCKET`
+3. `~/.logos/storage/libstorage/storage_lib.sock`
+
+`storage-test.sh` passes `--socket "$STORAGE_LIB_SOCKET"` explicitly.
+
+The daemon IPC protocol is intentionally simple:
+
+- Request: one whitespace-separated command line per connection.
+- Response: one JSON line like `{"ok":true,"result":"..."}` or `{"ok":false,"error":"..."}`.
+- Paths with spaces are not supported yet.
+
+Important: lib daemon file paths are resolved in the daemon process working directory. `storage-test.sh` converts upload/download paths to absolute paths before sending them to `storage_lib_ctl`.
+
+`--timeout-ms 0` means wait indefinitely in libstorage C++ tooling.
+
+Lib-only utility behavior:
+
+- `debug` calls daemon `debug` and pretty-prints the returned JSON with `jq .`.
+- `peers` calls daemon `debug` and prints `.table.nodes | length`, giving the number of peers known to the node.
+- Lifecycle commands (`shutdown`, `destroy`) intentionally remain out of `storage-test.sh`; use `tools/libstorage-cpp/storage_lib_ctl` directly for lifecycle testing.
+
+## Test Scenario
+
+`storage-test.sh <local|lib> test` currently runs the remote-to-local scenario:
+
+1. Generate random files with sizes from `TEST_FILE_SIZES`.
+2. Upload each file to the `remote` Linode REST node.
+3. Measure manifest resolution through selected target.
+4. Measure network stream-to-sink through selected target.
+5. Measure local-only write through selected target.
+6. Validate SHA-256 of source and downloaded file.
+7. Delete involved CIDs from the selected local target and `remote`.
+8. Remove temp workspace unless `TEST_KEEP_FILES=1`.
+9. Write a Markdown report in the caller's current directory: `./report-YYYY-MM-DD_HH-MM-SS.md`.
+
+Defaults:
+
+- `TEST_FILE_SIZES="4K 1M 10M"`
+- `TEST_KEEP_FILES=0`
+- Max per-file test size is 10 MB.
+
+The report includes timestamps, duration, target, file size list, workspace path, per-file CID/hash/path details, manifest time, network stream time/speed, local write time/speed, total time/speed, and cleanup results. `report-*.md` is ignored by the root `.gitignore`.
+
+The metrics flow intentionally mirrors storage-module/UI primitives while splitting work for more detail. REST local uses `/network/manifest`, `/network/stream` to `/dev/null`, then local-only `/data/{cid}`. Lib uses daemon `manifest`, `stream-sink`, then local-only `download`.
+
+## Verification Commands
+
+Use lightweight checks before/after edits:
+
+```bash
+bash -n tools/storage-test/storage-test.sh
+bash -n tools/storage-test/start-local-node.sh
+tools/storage-test/storage-test.sh --help
+tools/storage-test/start-local-node.sh --help
+```
+
+For lib daemon smoke tests:
+
+```bash
+cd tools/libstorage-cpp
+make storage_lib storage_lib_ctl
+cd ../..
+tools/storage-test/start-local-node.sh --client lib --data-dir /tmp/storage-lib-data --socket /tmp/storage-lib.sock --log-level FATAL --timeout-ms 0
+```
+
+In another shell:
+
+```bash
+STORAGE_LIB_SOCKET=/tmp/storage-lib.sock tools/storage-test/storage-test.sh lib peerid
+STORAGE_LIB_SOCKET=/tmp/storage-lib.sock tools/libstorage-cpp/storage_lib_ctl shutdown
+```
+
+Full `local test` and `lib test` contact the Linode remote and perform real uploads/downloads; run them deliberately.
+
+## Future Work
+
+- Add reverse scenario: selected local/lib target uploads, remote downloads/fetches, validates hashes, and cleans up.
+- Consider changing daemon IPC to JSON requests if argument quoting or paths with spaces become important.
+- Keep long-running/scenario behavior in `storage-test.sh`, not in the daemon, so scenarios can run against all targets.

--- a/tools/storage-test/README.md
+++ b/tools/storage-test/README.md
@@ -1,0 +1,280 @@
+# Storage Test Scripts
+
+Helpers for running a local Logos Storage node and testing it against the Linode node.
+
+## Remote Node
+
+The Linode node is running as a `systemd` service:
+
+```bash
+ssh storage@172.235.163.25
+systemctl status logos-storage.service
+journalctl -u logos-storage.service -f
+```
+
+Remote node ports:
+
+| Purpose | Address |
+|---|---|
+| P2P TCP | `172.235.163.25:8070` |
+| Discovery UDP | `172.235.163.25:8090` |
+| REST API | `127.0.0.1:8080` on the Linode only |
+
+The REST API is not exposed publicly. Use the SSH tunnel managed by `storage-test.sh`.
+
+## Start A Local Node
+
+Build the local binary first if needed:
+
+```bash
+make -j1 NIMFLAGS="-d:disableMarchNative"
+```
+
+Start a local node in the foreground:
+
+```bash
+tools/storage-test/start-local-node.sh
+```
+
+Start a libstorage-based local node in the foreground:
+
+```bash
+tools/storage-test/start-local-node.sh --client lib
+```
+
+Default local settings:
+
+| Setting | Default |
+|---|---|
+| Binary | `./build/storage` |
+| Data dir | `~/.logos/storage/local-node` for `storage`, `~/.logos/storage/libstorage/node` for `lib` |
+| Log level | `info` |
+| P2P TCP | `8071` |
+| Discovery UDP | `8091` |
+| REST API | `127.0.0.1:8080` |
+| Lib IPC socket | `~/.logos/storage/libstorage/storage_lib.sock` |
+| Network | `logos.test` |
+
+`info` is a good default log level: it shows startup, networking, and high-level node events without the volume of `debug` or `trace`.
+
+Use `debug` when diagnosing behavior:
+
+```bash
+tools/storage-test/start-local-node.sh --log-level debug
+```
+
+Use `trace` only for detailed protocol/debug investigation because it can be noisy:
+
+```bash
+tools/storage-test/start-local-node.sh --log-level trace
+```
+
+Show all local-node options:
+
+```bash
+tools/storage-test/start-local-node.sh --help
+```
+
+The local node runs in the foreground. Press `Ctrl-C` to stop it.
+
+## Test Helper
+
+Show commands:
+
+```bash
+tools/storage-test/storage-test.sh --help
+```
+
+Defaults:
+
+| Setting | Default |
+|---|---|
+| Remote SSH | `storage@172.235.163.25` |
+| Remote API tunnel | `127.0.0.1:18080` |
+| Local API | `127.0.0.1:8080` |
+| Libstorage socket | `~/.logos/storage/libstorage/storage_lib.sock` |
+| CID state file | `~/.logos/storage/test/cids.log` |
+| Generated test files | `~/.logos/storage/test/files/` |
+
+`cids.log` is a simple upload history. Each upload appends the timestamp, target, returned CID, and source file path. It is useful when running frequent tests because you can recover old CIDs and delete them later without scrolling terminal history.
+
+Recover the latest CID from the upload history:
+
+```bash
+tools/storage-test/storage-test.sh last-cid
+tools/storage-test/storage-test.sh last-cid remote
+```
+
+## SSH Tunnel
+
+Start the tunnel:
+
+```bash
+tools/storage-test/storage-test.sh tunnel start
+```
+
+Check it:
+
+```bash
+tools/storage-test/storage-test.sh tunnel status
+```
+
+Stop it:
+
+```bash
+tools/storage-test/storage-test.sh tunnel stop
+```
+
+You do not have to stop the tunnel after each test. It is safe to leave it running while you are actively testing. Stop it when you are done, when you want to free local port `18080`, or before changing tunnel settings.
+
+Commands that target `remote` start the tunnel automatically if it is not already running.
+
+## Typical Workflow
+
+Terminal 1: start local node and watch logs.
+
+```bash
+tools/storage-test/start-local-node.sh --log-level info
+```
+
+Terminal 2: upload random content to the Linode node.
+
+```bash
+CID="$(tools/storage-test/storage-test.sh remote upload-random 10M)"
+printf '%s\n' "$CID"
+```
+
+If you prefer copy/paste, you can also run the upload command directly and copy the printed CID:
+
+```bash
+tools/storage-test/storage-test.sh remote upload-random 10M
+```
+
+Recover it later from the upload history:
+
+```bash
+CID="$(tools/storage-test/storage-test.sh last-cid remote)"
+```
+
+Ask the local node to fetch and store the content from the network:
+
+```bash
+tools/storage-test/storage-test.sh local fetch "$CID" --wait
+```
+
+Or stream the content through the local node without explicitly storing it first:
+
+```bash
+tools/storage-test/storage-test.sh local download "$CID" /tmp/logos-download.bin
+```
+
+Check local presence:
+
+```bash
+tools/storage-test/storage-test.sh local exists "$CID"
+```
+
+List local, remote, and lib CIDs:
+
+```bash
+tools/storage-test/storage-test.sh local list
+tools/storage-test/storage-test.sh remote list
+tools/storage-test/storage-test.sh lib list
+```
+
+Delete by CID:
+
+```bash
+tools/storage-test/storage-test.sh local delete "$CID"
+tools/storage-test/storage-test.sh remote delete "$CID"
+```
+
+Delete all local CIDs:
+
+```bash
+tools/storage-test/storage-test.sh local delete-all --yes
+```
+
+Delete all remote CIDs:
+
+```bash
+tools/storage-test/storage-test.sh remote delete-all --yes
+```
+
+## Libstorage Daemon Target
+
+Build and start the libstorage daemon from `tools/libstorage-cpp`:
+
+```bash
+cd tools/libstorage-cpp
+make
+cd ../..
+tools/storage-test/start-local-node.sh --client lib
+```
+
+Then use the `lib` target from the repository root:
+
+```bash
+tools/storage-test/storage-test.sh lib peerid
+tools/storage-test/storage-test.sh lib upload README.md
+tools/storage-test/storage-test.sh lib download <CID> /tmp/logos-lib-download.bin
+tools/storage-test/storage-test.sh lib spr
+tools/storage-test/storage-test.sh lib debug
+```
+
+Override the socket with `STORAGE_LIB_SOCKET` if the daemon was started with a non-default socket path.
+
+## Test Scenario
+
+Run the first remote-to-local scenario against a standard local REST node:
+
+```bash
+tools/storage-test/storage-test.sh local test
+```
+
+Run the same scenario against the libstorage daemon:
+
+```bash
+tools/storage-test/storage-test.sh lib test
+```
+
+The scenario uploads random files to the remote Linode node, measures manifest resolution, network stream-to-sink, and local-only write through the selected local target, validates SHA-256 hashes, and deletes involved CIDs from both sides. The default file sizes are `4K 1M 10M`; override with `TEST_FILE_SIZES`.
+
+The per-file metrics are `Manifest Time`, `Network Stream Time`, `Network Stream Speed`, `Local Write Time`, `Local Write Speed`, `Total Time`, and `Total Speed`. The local REST target uses `/network/manifest`, `/network/stream` to `/dev/null`, then local-only `/data/{cid}`. The lib target uses `manifest`, `stream-sink`, then local-only `download` through the daemon.
+
+The scenario prints a detailed progress summary and writes a Markdown report in the current directory:
+
+```text
+./report-YYYY-MM-DD_HH-MM-SS.md
+```
+
+## Useful API Endpoints
+
+| Operation | Endpoint |
+|---|---|
+| Upload | `POST /api/storage/v1/data` |
+| List local content | `GET /api/storage/v1/data` |
+| Delete local content | `DELETE /api/storage/v1/data/{cid}` |
+| Fetch from network into node | `POST /api/storage/v1/data/{cid}/network` |
+| Fetch progress | `GET /api/storage/v1/data/{cid}/network/progress/{downloadId}` |
+| Stream from network | `GET /api/storage/v1/data/{cid}/network/stream` |
+| Stream local-only | `GET /api/storage/v1/data/{cid}` |
+| Local existence check | `GET /api/storage/v1/data/{cid}/exists` |
+| Storage space | `GET /api/storage/v1/space` |
+
+## Cleanup
+
+Stop the local node with `Ctrl-C`.
+
+Stop the SSH tunnel when finished:
+
+```bash
+tools/storage-test/storage-test.sh tunnel stop
+```
+
+Remove local test data if desired:
+
+```bash
+rm -rf ~/.logos/storage/local-node
+rm -rf ~/.logos/storage/test
+```

--- a/tools/storage-test/SETUP_STORAGE_NODE.md
+++ b/tools/storage-test/SETUP_STORAGE_NODE.md
@@ -1,0 +1,398 @@
+# Logos Storage Node Machine Setup Recipe
+
+This recipe describes how to prepare a fresh machine to run a headless Logos Storage node. It is written for a human operator or an AI agent that can SSH into the target machine and execute administrative commands.
+
+The first section is system-independent. The second section gives the concrete Ubuntu 24.04 setup used for the Linode test node.
+
+## Goal
+
+Set up a machine that:
+
+- Runs Logos Storage as a non-root service user.
+- Keeps the REST API bound to localhost only.
+- Exposes only the P2P and discovery ports publicly.
+- Can be administered over SSH using key-based login.
+- Starts the node automatically on boot using the host service manager.
+
+## Target Runtime Shape
+
+| Purpose | Default Used Here | Protocol | Exposure |
+|---|---:|---|---|
+| SSH | `22` | TCP | Restricted to operator IP |
+| P2P listen | `8070` | TCP | Public |
+| Discovery | `8090` | UDP | Public |
+| REST API | `8080` | TCP | Localhost only |
+
+The storage node command should look conceptually like:
+
+```bash
+storage \
+  --data-dir=<data-dir> \
+  --listen-port=8070 \
+  --disc-port=8090
+```
+
+Do not pass `--api-bindaddr=0.0.0.0` unless there is a deliberate reason to expose the API. The default API bind address is `127.0.0.1`.
+
+## Generic Setup Steps
+
+1. Provision a machine.
+
+Choose a machine with enough resources for the intended workload. For running the node, a small machine can work. For compiling on the machine, prefer at least 2 vCPU and 2-4 GB RAM. A 1 vCPU / 1 GB RAM machine can build, but slowly and may need extra swap.
+
+2. Configure firewall rules.
+
+Inbound rules:
+
+| Purpose | Protocol | Port | Source |
+|---|---:|---:|---|
+| SSH | TCP | `22` | Operator IP only, if possible |
+| Storage P2P | TCP | `8070` | Public IPv4/IPv6 as needed |
+| Storage Discovery | UDP | `8090` | Public IPv4/IPv6 as needed |
+
+Do not open `8080/TCP` publicly. Access the API over SSH tunneling.
+
+3. Create a non-root service user.
+
+Create a dedicated user, for example `storage`. The node process should run as this user, not as `root`.
+
+4. Configure SSH access.
+
+Install the operator public SSH key for the service/admin user. Verify login works before disabling root login. Then harden SSH:
+
+```text
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+```
+
+5. Install build/runtime prerequisites.
+
+Install a C/C++ toolchain, `git`, `cmake`, `curl`, `make`, `bash`, and runtime libraries required by the build. If building from source, install Nim `2.2.10`, preferably through `choosenim`.
+
+6. Clone and build Logos Storage.
+
+Clone `https://github.com/logos-storage/logos-storage-nim.git`, initialize submodules, and build:
+
+```bash
+make update
+make NIMFLAGS="-d:disableMarchNative"
+```
+
+Use low parallelism on small machines:
+
+```bash
+make -j1 NIMFLAGS="-d:disableMarchNative"
+```
+
+`-d:disableMarchNative` is recommended for Linux amd64 release/test artifacts to avoid leaking build-machine CPU choices into the binary and to avoid known GCC/secp256k1 x86_64 asm failures.
+
+7. Install the binary.
+
+Install the built binary somewhere stable, for example:
+
+```text
+/opt/logos-storage/storage
+```
+
+Keep source checkout and runtime data separate.
+
+8. Create the data directory.
+
+Use a dedicated persistent data directory owned by the service user, for example:
+
+```text
+/var/lib/logos-storage
+```
+
+9. Create a service.
+
+Use the platform service manager to run the node as the non-root service user, restart on failure, and start on boot.
+
+10. Verify.
+
+Verify:
+
+- Service is running.
+- TCP `8070` listens on all addresses.
+- UDP `8090` listens on all addresses.
+- TCP `8080` listens only on `127.0.0.1`.
+- `GET http://127.0.0.1:8080/api/storage/v1/peerid` returns a peer ID locally.
+- External TCP connectivity to `8070` works.
+
+## Ubuntu 24.04 Example
+
+This example assumes:
+
+- Ubuntu 24.04 LTS.
+- Initial SSH access as `root`.
+- Desired user: `storage`.
+- Public IP: replace `SERVER_IP` with the host IP.
+- Repository branch: `master`.
+
+### 1. Update The System
+
+```bash
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade
+reboot
+```
+
+Reconnect after reboot and verify:
+
+```bash
+apt list --upgradable
+test ! -f /var/run/reboot-required
+```
+
+### 2. Create The `storage` User
+
+```bash
+adduser --disabled-password --gecos "" storage
+usermod -aG sudo storage
+install -d -m 700 -o storage -g storage /home/storage/.ssh
+install -m 600 -o storage -g storage /root/.ssh/authorized_keys /home/storage/.ssh/authorized_keys
+```
+
+Optional passwordless sudo for bootstrap/admin work:
+
+```bash
+printf 'storage ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/90-storage-user
+chmod 440 /etc/sudoers.d/90-storage-user
+visudo -cf /etc/sudoers.d/90-storage-user
+```
+
+From the operator machine, verify:
+
+```bash
+ssh storage@SERVER_IP 'whoami; id; sudo -n true'
+```
+
+### 3. Harden SSH
+
+Create a drop-in:
+
+```bash
+install -d -m 755 /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/99-logos-storage-hardening.conf <<'EOF'
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+EOF
+sshd -t
+systemctl restart ssh || systemctl restart sshd
+```
+
+Verify from the operator machine:
+
+```bash
+ssh storage@SERVER_IP 'true'
+ssh -o BatchMode=yes root@SERVER_IP 'true'
+```
+
+The root command should fail.
+
+### 4. Install Packages
+
+```bash
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  cmake \
+  git \
+  curl \
+  make \
+  bash \
+  lcov \
+  libgomp1 \
+  jq \
+  ca-certificates \
+  pkg-config
+```
+
+### 5. Add Swap On Small Machines
+
+On very small machines, for example 1 GB RAM, add a swap file before building:
+
+```bash
+if [ ! -f /swapfile ]; then
+  sudo fallocate -l 2G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=2048
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  sudo swapon /swapfile
+fi
+grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+free -h
+```
+
+### 6. Install Nim 2.2.10 With `choosenim`
+
+Run as the `storage` user:
+
+```bash
+curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+export PATH="$HOME/.nimble/bin:$PATH"
+choosenim 2.2.10
+nim --version
+```
+
+Persist PATH:
+
+```bash
+grep -qxF 'export PATH=$HOME/.nimble/bin:$PATH' ~/.profile || \
+  printf '\nexport PATH=$HOME/.nimble/bin:$PATH\n' >> ~/.profile
+```
+
+### 7. Clone And Build
+
+Run as the `storage` user:
+
+```bash
+git clone https://github.com/logos-storage/logos-storage-nim.git ~/logos-storage-nim
+cd ~/logos-storage-nim
+make -j1 update
+make -j1 NIMFLAGS="-d:disableMarchNative"
+./build/storage --help >/dev/null
+```
+
+On larger machines, use higher parallelism, for example:
+
+```bash
+make -j"$(nproc)" update
+make -j"$(nproc)" NIMFLAGS="-d:disableMarchNative"
+```
+
+### 8. Install Binary And Data Directory
+
+```bash
+sudo install -d -m 755 -o root -g root /opt/logos-storage
+sudo install -m 755 -o root -g root ~/logos-storage-nim/build/storage /opt/logos-storage/storage
+sudo install -d -m 700 -o storage -g storage /var/lib/logos-storage
+/opt/logos-storage/storage --help >/dev/null
+```
+
+### 9. Create `systemd` Service
+
+```bash
+sudo tee /etc/systemd/system/logos-storage.service >/dev/null <<'EOF'
+[Unit]
+Description=Logos Storage Node
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=storage
+Group=storage
+WorkingDirectory=/var/lib/logos-storage
+ExecStart=/opt/logos-storage/storage --data-dir=/var/lib/logos-storage --listen-port=8070 --disc-port=8090
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=1048576
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=/var/lib/logos-storage
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now logos-storage.service
+```
+
+### 10. Verify Service And Ports
+
+```bash
+systemctl --no-pager --full status logos-storage.service
+ss -lntup | grep -E ':(8070|8080|8090)\b'
+curl -fsS http://127.0.0.1:8080/api/storage/v1/peerid
+curl -fsS http://127.0.0.1:8080/api/storage/v1/spr
+journalctl -u logos-storage.service --no-pager -n 80
+```
+
+Expected bindings:
+
+```text
+udp 0.0.0.0:8090
+tcp 127.0.0.1:8080
+tcp 0.0.0.0:8070
+```
+
+From the operator machine, verify public TCP reachability:
+
+```bash
+timeout 10 bash -c 'cat < /dev/null > /dev/tcp/SERVER_IP/8070' && echo open
+```
+
+UDP reachability is harder to verify with a simple shell one-liner. Confirm the firewall rule exists and inspect node logs for discovery startup and advertised `/udp/8090` addresses.
+
+## API Access From Operator Machine
+
+Keep the API private and tunnel over SSH:
+
+```bash
+ssh -N -L 127.0.0.1:18080:127.0.0.1:8080 storage@SERVER_IP
+```
+
+Then use:
+
+```bash
+curl http://127.0.0.1:18080/api/storage/v1/peerid
+```
+
+In this repository, `tools/storage-test/storage-test.sh` manages this tunnel automatically for commands targeting `remote`.
+
+## Operational Commands
+
+```bash
+sudo systemctl start logos-storage.service
+sudo systemctl stop logos-storage.service
+sudo systemctl restart logos-storage.service
+systemctl status logos-storage.service
+journalctl -u logos-storage.service -f
+```
+
+## Troubleshooting
+
+### SSH Hangs During Build
+
+Symptoms:
+
+```text
+Connection timed out during banner exchange
+```
+
+Likely cause: small VM overloaded by compilation. Use `make -j1`, add swap, or build on a larger machine and copy the binary.
+
+### REST API Is Unreachable Externally
+
+This is expected. The REST API should bind to `127.0.0.1:8080`. Use SSH tunneling.
+
+### Node Has No Peers
+
+Check:
+
+- Firewall allows `8070/TCP` and `8090/UDP`.
+- Service logs show public IP in advertised addresses.
+- The machine has public internet access.
+- The network preset is the intended one, for example `logos.test`.
+
+### Data Directory Permissions Warning
+
+The node may correct permissions on startup. Prefer setting the directory explicitly:
+
+```bash
+sudo chmod 700 /var/lib/logos-storage
+sudo chown storage:storage /var/lib/logos-storage
+```
+
+## Security Notes
+
+- Do not run the node as `root`.
+- Do not expose API port `8080` publicly.
+- Restrict SSH source IPs in the cloud firewall.
+- Keep outbound traffic allowed unless there is a specific network policy.
+- Treat the node private key in the data directory as sensitive.

--- a/tools/storage-test/start-local-node.sh
+++ b/tools/storage-test/start-local-node.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+CLIENT="${STORAGE_CLIENT:-storage}"
+BINARY="${STORAGE_BINARY:-${ROOT_DIR}/build/storage}"
+LIB_BINARY="${STORAGE_LIB_BINARY:-${ROOT_DIR}/tools/libstorage-cpp/storage_lib}"
+STORAGE_DATA_DIR_DEFAULT="${HOME}/.logos/storage/local-node"
+LIB_DATA_DIR_DEFAULT="${HOME}/.logos/storage/libstorage/node"
+DATA_DIR="${STORAGE_DATA_DIR:-}"
+LOG_LEVEL="${STORAGE_LOG_LEVEL:-info}"
+LISTEN_PORT="${STORAGE_LISTEN_PORT:-8071}"
+DISC_PORT="${STORAGE_DISC_PORT:-8091}"
+API_BINDADDR="${STORAGE_API_BINDADDR:-127.0.0.1}"
+API_PORT="${STORAGE_API_PORT:-8080}"
+NETWORK="${STORAGE_NETWORK:-logos.test}"
+LIB_SOCKET="${STORAGE_LIB_SOCKET:-${HOME}/.logos/storage/libstorage/storage_lib.sock}"
+LIB_TIMEOUT_MS="${STORAGE_LIB_TIMEOUT_MS:-0}"
+LIB_CHUNK_SIZE="${STORAGE_LIB_CHUNK_SIZE:-65536}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options] [-- extra args]
+
+Start a local Logos Storage node in the foreground so logs are visible.
+
+Options:
+  --client <name>       Client to launch: storage or lib [$CLIENT]
+  --binary <path>       Storage binary [$BINARY]
+  --lib-binary <path>   Libstorage daemon binary [$LIB_BINARY]
+  --data-dir <path>     Data directory [storage: $STORAGE_DATA_DIR_DEFAULT, lib: $LIB_DATA_DIR_DEFAULT]
+  --log-level <level>   Log level: trace, debug, info, notice, warn, error [$LOG_LEVEL]
+  --listen-port <port>  Local libp2p TCP listen port [$LISTEN_PORT]
+  --disc-port <port>    Local discovery UDP port [$DISC_PORT]
+  --api-bindaddr <ip>   REST API bind address [$API_BINDADDR]
+  --api-port <port>     REST API port [$API_PORT]
+  --network <name>      Network preset [$NETWORK]
+  --socket <path>       Libstorage Unix socket [$LIB_SOCKET]
+  --timeout-ms <ms>     Libstorage async timeout, 0 waits forever [$LIB_TIMEOUT_MS]
+  --chunk-size <bytes>  Libstorage upload/download chunk size [$LIB_CHUNK_SIZE]
+  -h, --help            Show this help.
+
+Environment overrides:
+  STORAGE_CLIENT, STORAGE_BINARY, STORAGE_LIB_BINARY, STORAGE_DATA_DIR,
+  STORAGE_LOG_LEVEL, STORAGE_LISTEN_PORT, STORAGE_DISC_PORT, STORAGE_API_BINDADDR,
+  STORAGE_API_PORT, STORAGE_NETWORK, STORAGE_LIB_SOCKET, STORAGE_LIB_TIMEOUT_MS,
+  STORAGE_LIB_CHUNK_SIZE
+
+Examples:
+  $0
+  $0 --client lib
+  $0 --log-level debug
+  $0 --data-dir /tmp/logos-storage-local --listen-port 8072 --disc-port 8092
+  $0 --log-level trace -- --metrics --metrics-address=127.0.0.1
+
+The node runs in the foreground. Press Ctrl-C to stop it.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --client)
+      CLIENT="${2:-}"
+      shift 2
+      ;;
+    --binary)
+      BINARY="${2:-}"
+      shift 2
+      ;;
+    --lib-binary)
+      LIB_BINARY="${2:-}"
+      shift 2
+      ;;
+    --data-dir)
+      DATA_DIR="${2:-}"
+      shift 2
+      ;;
+    --log-level)
+      LOG_LEVEL="${2:-}"
+      shift 2
+      ;;
+    --listen-port)
+      LISTEN_PORT="${2:-}"
+      shift 2
+      ;;
+    --disc-port)
+      DISC_PORT="${2:-}"
+      shift 2
+      ;;
+    --api-bindaddr)
+      API_BINDADDR="${2:-}"
+      shift 2
+      ;;
+    --api-port)
+      API_PORT="${2:-}"
+      shift 2
+      ;;
+    --network)
+      NETWORK="${2:-}"
+      shift 2
+      ;;
+    --socket)
+      LIB_SOCKET="${2:-}"
+      shift 2
+      ;;
+    --timeout-ms)
+      LIB_TIMEOUT_MS="${2:-}"
+      shift 2
+      ;;
+    --chunk-size)
+      LIB_CHUNK_SIZE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      printf 'error: unknown option: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$CLIENT" in
+  storage|lib) ;;
+  *) printf 'error: --client must be storage or lib\n' >&2; exit 1 ;;
+esac
+
+if [[ -z "$DATA_DIR" ]]; then
+  if [[ "$CLIENT" == 'lib' ]]; then
+    DATA_DIR="$LIB_DATA_DIR_DEFAULT"
+  else
+    DATA_DIR="$STORAGE_DATA_DIR_DEFAULT"
+  fi
+fi
+
+if [[ "$CLIENT" == 'storage' ]]; then
+  [[ -n "$BINARY" ]] || { printf 'error: --binary cannot be empty\n' >&2; exit 1; }
+  [[ -x "$BINARY" ]] || { printf 'error: storage binary not executable: %s\n' "$BINARY" >&2; exit 1; }
+else
+  [[ -n "$LIB_BINARY" ]] || { printf 'error: --lib-binary cannot be empty\n' >&2; exit 1; }
+  [[ -x "$LIB_BINARY" ]] || { printf 'error: libstorage daemon binary not executable: %s\n' "$LIB_BINARY" >&2; exit 1; }
+fi
+
+mkdir -p "$DATA_DIR"
+
+printf 'Starting local Logos Storage node\n'
+printf '  client:      %s\n' "$CLIENT"
+if [[ "$CLIENT" == 'storage' ]]; then
+  printf '  binary:      %s\n' "$BINARY"
+else
+  printf '  binary:      %s\n' "$LIB_BINARY"
+fi
+printf '  data dir:    %s\n' "$DATA_DIR"
+printf '  log level:   %s\n' "$LOG_LEVEL"
+printf '  listen TCP:  %s\n' "$LISTEN_PORT"
+printf '  discovery:   %s/udp\n' "$DISC_PORT"
+printf '  network:     %s\n' "$NETWORK"
+if [[ "$CLIENT" == 'storage' ]]; then
+  printf '  REST API:    %s:%s\n' "$API_BINDADDR" "$API_PORT"
+else
+  printf '  socket:      %s\n' "$LIB_SOCKET"
+  printf '  timeout ms:  %s\n' "$LIB_TIMEOUT_MS"
+  printf '  chunk size:  %s\n' "$LIB_CHUNK_SIZE"
+fi
+printf '\n'
+
+if [[ "$CLIENT" == 'storage' ]]; then
+  exec "$BINARY" \
+    --data-dir="$DATA_DIR" \
+    --log-level="$LOG_LEVEL" \
+    --listen-port="$LISTEN_PORT" \
+    --disc-port="$DISC_PORT" \
+    --api-bindaddr="$API_BINDADDR" \
+    --api-port="$API_PORT" \
+    --network="$NETWORK" \
+    "$@"
+fi
+
+exec "$LIB_BINARY" \
+  --data-dir "$DATA_DIR" \
+  --log-level "$LOG_LEVEL" \
+  --listen-port "$LISTEN_PORT" \
+  --disc-port "$DISC_PORT" \
+  --network "$NETWORK" \
+  --socket "$LIB_SOCKET" \
+  --timeout-ms "$LIB_TIMEOUT_MS" \
+  --chunk-size "$LIB_CHUNK_SIZE" \
+  "$@"

--- a/tools/storage-test/storage-test.sh
+++ b/tools/storage-test/storage-test.sh
@@ -439,8 +439,10 @@ target_download_cid() {
     die 'download only supports optional --local'
   fi
 
+  out="$(abs_output_path "$out")"
+
   if [[ "$target" == 'lib' ]]; then
-    lib_result download "$cid" "$(abs_output_path "$out")" "$local_only" >/dev/null
+    lib_result download "$cid" "$out" "$local_only" >/dev/null
   else
     check_common_deps
     local api

--- a/tools/storage-test/storage-test.sh
+++ b/tools/storage-test/storage-test.sh
@@ -642,7 +642,7 @@ target_test() {
       cleanup_messages+=("kept workspace $workspace")
     fi
   }
-  trap cleanup RETURN
+  trap cleanup ERR RETURN
 
   write_report() {
     local end_time end_epoch duration i
@@ -766,7 +766,7 @@ target_test() {
 
   printf '\nCleaning up remote and %s CIDs...\n' "$target"
   cleanup
-  trap - RETURN
+  trap - ERR RETURN
   write_report
 
   printf '\nTest passed\n'

--- a/tools/storage-test/storage-test.sh
+++ b/tools/storage-test/storage-test.sh
@@ -1,0 +1,843 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+REMOTE_SSH_HOST="${REMOTE_SSH_HOST:-storage@172.235.163.25}"
+REMOTE_API_PORT="${REMOTE_API_PORT:-18080}"
+LOCAL_API_PORT="${LOCAL_API_PORT:-8080}"
+TUNNEL_CONTROL_PATH="${TUNNEL_CONTROL_PATH:-/tmp/logos-storage-tunnel-${USER:-user}.ctl}"
+CID_STATE_FILE="${CID_STATE_FILE:-${HOME}/.logos/storage/test/cids.log}"
+TEST_FILES_DIR="${TEST_FILES_DIR:-${HOME}/.logos/storage/test/files}"
+TEST_FILE_SIZES="${TEST_FILE_SIZES:-4K 1M 10M}"
+TEST_KEEP_FILES="${TEST_KEEP_FILES:-0}"
+STORAGE_LIB_CTL="${STORAGE_LIB_CTL:-${ROOT_DIR}/tools/libstorage-cpp/storage_lib_ctl}"
+STORAGE_LIB_SOCKET="${STORAGE_LIB_SOCKET:-${HOME}/.logos/storage/libstorage/storage_lib.sock}"
+
+LOCAL_API="http://127.0.0.1:${LOCAL_API_PORT}/api/storage/v1"
+REMOTE_API="http://127.0.0.1:${REMOTE_API_PORT}/api/storage/v1"
+
+usage() {
+  cat <<EOF
+Usage: $0 <target> <command> [args]
+       $0 <global-command> [args]
+
+Targets:
+  local                 Local REST node at $LOCAL_API
+  remote                Remote REST node through SSH tunnel at $REMOTE_API
+  lib                   Local storage_lib daemon via Unix socket
+
+Target commands:
+  <target> upload <file>
+      Upload a file and print the returned CID.
+
+  <target> upload-random <size> [--keep]
+      Create random content, upload it, print CID.
+
+  <target> download <cid> <output-file> [--local]
+      Download CID into output-file. For lib, --local means local store only.
+
+  <target> fetch <cid> [--wait]
+      Fetch CID from network into target local store. --wait is REST-only.
+
+  <target> stream-sink <cid> [--local]
+      Stream CID and discard data. Used by test metrics.
+
+  <target> list
+      List manifest CIDs stored locally by target.
+
+  <target> delete <cid>
+      Delete CID from target local storage.
+
+  <target> delete-all --yes
+      Delete every CID returned by list from target local storage.
+
+  <target> exists <cid>
+      Check whether target has CID locally.
+
+  <target> space
+      Show target storage space information.
+
+  <target> peerid
+      Show target peer ID.
+
+  <target> test
+      Upload random files to remote, measure manifest/network-stream/local-write,
+      validate hashes, and clean up involved CIDs. Supported targets: local, lib.
+
+Lib-only target commands:
+  lib spr
+  lib debug
+  lib peers
+  lib manifest <cid>
+  lib connect <peer-id> [addr...]
+
+Global commands:
+  help
+      Show this help.
+
+  tunnel start|stop|status
+      Manage SSH tunnel to the remote REST API.
+
+  make-file <size> [output-file]
+      Create random content with dd. Example: make-file 10M /tmp/logos-10M.bin
+
+  last-cid [target]
+      Print the most recent CID from CID_STATE_FILE, optionally filtered by target.
+
+Environment:
+  REMOTE_SSH_HOST       SSH host for the remote node [$REMOTE_SSH_HOST]
+  REMOTE_API_PORT       Local tunnel port for remote API [$REMOTE_API_PORT]
+  LOCAL_API_PORT        Local node API port [$LOCAL_API_PORT]
+  STORAGE_LIB_CTL       Path to storage_lib_ctl [$STORAGE_LIB_CTL]
+  STORAGE_LIB_SOCKET    Unix socket for storage_lib [$STORAGE_LIB_SOCKET]
+  CID_STATE_FILE        Upload history log [$CID_STATE_FILE]
+  TEST_FILES_DIR        Generated test file directory [$TEST_FILES_DIR]
+  TEST_FILE_SIZES       Sizes used by '<target> test' [$TEST_FILE_SIZES]
+  TEST_KEEP_FILES       Keep test workspace when set to 1 [$TEST_KEEP_FILES]
+
+Examples:
+  $0 tunnel start
+  $0 remote upload-random 10M
+  $0 local fetch <CID> --wait
+  $0 local download <CID> /tmp/downloaded.bin
+  $0 lib download <CID> /tmp/downloaded.bin
+  $0 lib test
+  $0 local test
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+check_common_deps() {
+  need curl
+  need jq
+}
+
+is_target() {
+  case "${1:-}" in
+    local|remote|lib) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+target_api() {
+  case "${1:-}" in
+    local)
+      printf '%s\n' "$LOCAL_API"
+      ;;
+    remote)
+      tunnel_start >/dev/null
+      printf '%s\n' "$REMOTE_API"
+      ;;
+    *)
+      die "REST target must be 'local' or 'remote'"
+      ;;
+  esac
+}
+
+tunnel_status() {
+  ssh -S "$TUNNEL_CONTROL_PATH" -O check "$REMOTE_SSH_HOST" >/dev/null 2>&1
+}
+
+tunnel_start() {
+  need ssh
+  if tunnel_status; then
+    printf 'tunnel already running: 127.0.0.1:%s -> %s:127.0.0.1:8080\n' \
+      "$REMOTE_API_PORT" "$REMOTE_SSH_HOST"
+    return 0
+  fi
+
+  ssh \
+    -M \
+    -S "$TUNNEL_CONTROL_PATH" \
+    -fN \
+    -L "127.0.0.1:${REMOTE_API_PORT}:127.0.0.1:8080" \
+    "$REMOTE_SSH_HOST"
+
+  printf 'started tunnel: 127.0.0.1:%s -> %s:127.0.0.1:8080\n' \
+    "$REMOTE_API_PORT" "$REMOTE_SSH_HOST"
+}
+
+tunnel_stop() {
+  need ssh
+  if tunnel_status; then
+    ssh -S "$TUNNEL_CONTROL_PATH" -O exit "$REMOTE_SSH_HOST" >/dev/null
+    printf 'stopped tunnel\n'
+  else
+    printf 'tunnel not running\n'
+  fi
+}
+
+make_file() {
+  local size="${1:-}"
+  local out="${2:-}"
+  [[ -n "$size" ]] || die 'make-file requires <size>'
+  if [[ -z "$out" ]]; then
+    mkdir -p "$TEST_FILES_DIR"
+    out="${TEST_FILES_DIR}/logos-test-${size}-$(date -u +%Y%m%dT%H%M%SZ).bin"
+  fi
+  dd if=/dev/urandom of="$out" bs="$size" count=1 status=progress
+  printf '%s\n' "$out"
+}
+
+record_cid() {
+  local target="$1"
+  local cid="$2"
+  local file="$3"
+  mkdir -p "$(dirname "$CID_STATE_FILE")"
+  printf '%s %s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$target" "$cid" "$file" >> "$CID_STATE_FILE"
+}
+
+last_cid() {
+  local target=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      local|remote|lib)
+        [[ -z "$target" ]] || die 'target specified more than once'
+        target="$1"
+        ;;
+      *)
+        die "unknown last-cid option: $1"
+        ;;
+    esac
+    shift
+  done
+
+  [[ -f "$CID_STATE_FILE" ]] || die "CID state file not found: $CID_STATE_FILE"
+
+  local cid
+  if [[ -n "$target" ]]; then
+    cid="$(awk -v target="$target" '$2 == target { cid = $3 } END { print cid }' "$CID_STATE_FILE")"
+  else
+    cid="$(awk 'NF >= 3 { cid = $3 } END { print cid }' "$CID_STATE_FILE")"
+  fi
+
+  [[ -n "$cid" ]] || die 'no matching CID found'
+  printf '%s\n' "$cid"
+}
+
+lib_ctl_raw() {
+  [[ -x "$STORAGE_LIB_CTL" ]] || die "storage_lib_ctl not executable: $STORAGE_LIB_CTL"
+  "$STORAGE_LIB_CTL" --socket "$STORAGE_LIB_SOCKET" "$@"
+}
+
+lib_result() {
+  check_common_deps
+  local response
+  response="$(lib_ctl_raw "$@")"
+  if ! printf '%s\n' "$response" | jq -e '.ok == true' >/dev/null; then
+    printf '%s\n' "$response" >&2
+    return 1
+  fi
+  printf '%s\n' "$response" | jq -r '.result'
+}
+
+abs_existing_path() {
+  local path="$1"
+  [[ -e "$path" ]] || die "path not found: $path"
+  local dir base
+  dir="$(cd "$(dirname "$path")" && pwd)"
+  base="$(basename "$path")"
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+abs_output_path() {
+  local path="$1"
+  local dir base
+  dir="$(dirname "$path")"
+  base="$(basename "$path")"
+  mkdir -p "$dir"
+  dir="$(cd "$dir" && pwd)"
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+rest_upload_file() {
+  check_common_deps
+  local target="$1"
+  local file="$2"
+  [[ -f "$file" ]] || die "file not found: $file"
+  local api
+  api="$(target_api "$target")"
+  curl -fsS \
+    -H 'Content-Type: application/octet-stream' \
+    --data-binary "@${file}" \
+    "${api}/data"
+}
+
+target_upload_file() {
+  local target="$1"
+  local file="$2"
+  [[ -n "$file" ]] || die 'upload requires <file>'
+  local cid
+  if [[ "$target" == 'lib' ]]; then
+    cid="$(lib_result upload "$(abs_existing_path "$file")")"
+  else
+    cid="$(rest_upload_file "$target" "$file")"
+  fi
+  printf '%s\n' "$cid"
+  record_cid "$target" "$cid" "$file"
+}
+
+target_upload_random() {
+  local target="$1"
+  local size="${2:-}"
+  local keep=false
+  [[ -n "$size" ]] || die 'upload-random requires <size> [--keep]'
+
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --keep) keep=true ;;
+      *) die "unknown upload-random option: $1" ;;
+    esac
+    shift
+  done
+
+  local tmp cid
+  tmp="$(mktemp "${TMPDIR:-/tmp}/logos-storage-test.XXXXXX")"
+  dd if=/dev/urandom of="$tmp" bs="$size" count=1 status=progress >&2
+  cid="$(target_upload_file "$target" "$tmp")"
+  printf '%s\n' "$cid"
+
+  if [[ "$keep" == true ]]; then
+    printf 'kept file: %s\n' "$tmp" >&2
+  else
+    rm -f "$tmp"
+  fi
+}
+
+target_list_cids() {
+  local target="$1"
+  if [[ "$target" == 'lib' ]]; then
+    lib_result list | jq -r '.[]?.cid'
+    return 0
+  fi
+
+  check_common_deps
+  local api
+  api="$(target_api "$target")"
+  curl -fsS "${api}/data" | jq -r '.content[]?.cid'
+}
+
+target_delete_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  [[ -n "$cid" ]] || die 'delete requires <cid>'
+  if [[ "$target" == 'lib' ]]; then
+    lib_result delete "$cid" >/dev/null
+  else
+    check_common_deps
+    local api
+    api="$(target_api "$target")"
+    curl -fsS -X DELETE "${api}/data/${cid}" >/dev/null
+  fi
+  printf 'deleted %s from %s\n' "$cid" "$target"
+}
+
+target_delete_all() {
+  local target="$1"
+  local yes="${2:-}"
+  [[ "$yes" == '--yes' ]] || die 'delete-all requires --yes'
+
+  local cid count=0
+  while IFS= read -r cid; do
+    [[ -n "$cid" ]] || continue
+    target_delete_cid "$target" "$cid"
+    count=$((count + 1))
+  done < <(target_list_cids "$target")
+  printf 'deleted %d CID(s) from %s\n' "$count" "$target"
+}
+
+target_simple_get() {
+  local target="$1"
+  local path="$2"
+  if [[ "$target" == 'lib' ]]; then
+    case "$path" in
+      space) lib_result space ;;
+      peerid) lib_result peer-id ;;
+      *) die "unsupported lib get path: $path" ;;
+    esac
+    return 0
+  fi
+
+  check_common_deps
+  local api
+  api="$(target_api "$target")"
+  curl -fsS "${api}/${path}"
+  printf '\n'
+}
+
+target_exists_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  [[ -n "$cid" ]] || die 'exists requires <cid>'
+  if [[ "$target" == 'lib' ]]; then
+    lib_result exists "$cid"
+  else
+    target_simple_get "$target" "data/${cid}/exists"
+  fi
+}
+
+target_fetch_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  local wait="${3:-}"
+  [[ -n "$cid" ]] || die 'fetch requires <cid> [--wait]'
+  [[ -z "$wait" || "$wait" == '--wait' ]] || die 'only supported option is --wait'
+
+  if [[ "$target" == 'lib' ]]; then
+    [[ -z "$wait" ]] || printf 'warning: --wait is ignored for lib fetch\n' >&2
+    lib_result fetch "$cid"
+    return 0
+  fi
+
+  check_common_deps
+  local api response download_id
+  api="$(target_api "$target")"
+  response="$(curl -fsS -X POST "${api}/data/${cid}/network")"
+  printf '%s\n' "$response" | jq .
+
+  if [[ "$wait" != '--wait' ]]; then
+    return 0
+  fi
+
+  download_id="$(printf '%s\n' "$response" | jq -r '.downloadId // empty')"
+  [[ -n "$download_id" ]] || die 'response did not contain downloadId'
+
+  while true; do
+    local progress active received total
+    progress="$(curl -fsS "${api}/data/${cid}/network/progress/${download_id}")"
+    printf '%s\n' "$progress" | jq .
+    active="$(printf '%s\n' "$progress" | jq -r '.active')"
+    received="$(printf '%s\n' "$progress" | jq -r '.received // 0')"
+    total="$(printf '%s\n' "$progress" | jq -r '.total // 0')"
+    if [[ "$active" != 'true' || ( "$total" != '0' && "$received" == "$total" ) ]]; then
+      break
+    fi
+    sleep 2
+  done
+}
+
+target_download_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  local out="${3:-}"
+  local local_only=false
+  [[ -n "$cid" && -n "$out" ]] || die 'download requires <cid> <output-file> [--local]'
+  if [[ "${4:-}" == '--local' ]]; then
+    local_only=true
+  elif [[ -n "${4:-}" ]]; then
+    die 'download only supports optional --local'
+  fi
+
+  if [[ "$target" == 'lib' ]]; then
+    lib_result download "$cid" "$(abs_output_path "$out")" "$local_only" >/dev/null
+  else
+    check_common_deps
+    local api
+    api="$(target_api "$target")"
+    curl -fL "${api}/data/${cid}/network/stream" -o "$out"
+  fi
+  printf '%s\n' "$out"
+}
+
+lib_only_command() {
+  local command="$1"
+  shift
+  case "$command" in
+    spr)
+      [[ $# -eq 0 ]] || die "$command does not accept arguments"
+      lib_result "$command"
+      ;;
+    debug)
+      [[ $# -eq 0 ]] || die 'debug does not accept arguments'
+      lib_result debug | jq .
+      ;;
+    peers)
+      [[ $# -eq 0 ]] || die 'peers does not accept arguments'
+      lib_result debug | jq -r '.table.nodes | length'
+      ;;
+    manifest)
+      [[ $# -eq 1 ]] || die 'manifest requires <cid>'
+      lib_result manifest "$1"
+      ;;
+    connect)
+      [[ $# -ge 1 ]] || die 'connect requires <peer-id> [addr...]'
+      lib_result connect "$@"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+size_to_bytes() {
+  local value="$1"
+  local number suffix
+  number="${value%[KkMmGg]}"
+  suffix="${value:${#number}}"
+  [[ "$number" =~ ^[0-9]+$ ]] || die "invalid size: $value"
+  case "$suffix" in
+    K|k) printf '%s\n' $((number * 1024)) ;;
+    M|m) printf '%s\n' $((number * 1024 * 1024)) ;;
+    G|g) printf '%s\n' $((number * 1024 * 1024 * 1024)) ;;
+    '') printf '%s\n' "$number" ;;
+    *) die "invalid size suffix: $value" ;;
+  esac
+}
+
+now_ns() {
+  date +%s%N
+}
+
+elapsed_seconds() {
+  local start_ns="$1"
+  local end_ns="$2"
+  awk -v start="$start_ns" -v end="$end_ns" 'BEGIN { printf "%.3f", (end - start) / 1000000000 }'
+}
+
+sum_seconds() {
+  awk -v a="$1" -v b="$2" -v c="$3" 'BEGIN { printf "%.3f", a + b + c }'
+}
+
+format_speed() {
+  local bytes="$1"
+  local seconds="$2"
+  awk -v bytes="$bytes" -v seconds="$seconds" '
+    BEGIN {
+      if (seconds <= 0) {
+        printf "n/a"
+        exit
+      }
+      speed = bytes / seconds
+      unit = "B/s"
+      if (speed >= 1024) { speed /= 1024; unit = "KiB/s" }
+      if (speed >= 1024) { speed /= 1024; unit = "MiB/s" }
+      if (speed >= 1024) { speed /= 1024; unit = "GiB/s" }
+      printf "%.2f %s", speed, unit
+    }
+  '
+}
+
+target_manifest_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  [[ -n "$cid" ]] || die 'manifest requires <cid>'
+  if [[ "$target" == 'lib' ]]; then
+    lib_result manifest "$cid" >/dev/null
+    return 0
+  fi
+
+  check_common_deps
+  local api
+  api="$(target_api "$target")"
+  curl -fsS "${api}/data/${cid}/network/manifest" >/dev/null
+}
+
+target_stream_sink() {
+  local target="$1"
+  local cid="${2:-}"
+  local local_flag="${3:-}"
+  [[ -n "$cid" ]] || die 'stream-sink requires <cid> [--local]'
+  [[ -z "$local_flag" || "$local_flag" == '--local' ]] || die 'stream-sink only supports optional --local'
+
+  if [[ "$target" == 'lib' ]]; then
+    lib_result stream-sink "$cid" "$([[ "$local_flag" == '--local' ]] && printf true || printf false)" >/dev/null
+    return 0
+  fi
+
+  check_common_deps
+  local api path
+  api="$(target_api "$target")"
+  if [[ "$local_flag" == '--local' ]]; then
+    path="${api}/data/${cid}"
+  else
+    path="${api}/data/${cid}/network/stream"
+  fi
+  curl -fLsS "$path" -o /dev/null
+}
+
+target_download_local_cid() {
+  local target="$1"
+  local cid="${2:-}"
+  local out="${3:-}"
+  [[ -n "$cid" && -n "$out" ]] || die 'local download requires <cid> <output-file>'
+  if [[ "$target" == 'lib' ]]; then
+    target_download_cid lib "$cid" "$out" --local >/dev/null
+    return 0
+  fi
+
+  check_common_deps
+  local api
+  api="$(target_api "$target")"
+  curl -fLsS "${api}/data/${cid}" -o "$out"
+}
+
+target_test() {
+  local target="$1"
+  [[ "$target" == 'local' || "$target" == 'lib' ]] || die 'test is supported only for local and lib targets'
+  check_common_deps
+  need sha256sum
+
+  local max_bytes=$((10 * 1024 * 1024))
+  local workspace report_ts report_path start_time start_epoch cleanup_done=0 cleanup_failures=0
+  workspace="$(mktemp -d "${TMPDIR:-/tmp}/logos-storage-test.XXXXXX")"
+  report_ts="$(date +%Y-%m-%d_%H-%M-%S)"
+  report_path="./report-${report_ts}.md"
+  start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  start_epoch="$(date +%s)"
+  local -a cids=()
+  local -a local_cids=()
+  local -a result_sizes=()
+  local -a result_bytes=()
+  local -a result_sources=()
+  local -a result_downloads=()
+  local -a result_cids=()
+  local -a result_hashes=()
+  local -a result_manifest_times=()
+  local -a result_network_times=()
+  local -a result_network_speeds=()
+  local -a result_write_times=()
+  local -a result_write_speeds=()
+  local -a result_total_times=()
+  local -a result_total_speeds=()
+  local -a cleanup_messages=()
+
+  cleanup() {
+    if [[ "$cleanup_done" == '1' ]]; then
+      return 0
+    fi
+    cleanup_done=1
+    local cid
+    for cid in "${local_cids[@]:-}"; do
+      if target_delete_cid "$target" "$cid" >/dev/null 2>&1; then
+        cleanup_messages+=("deleted $cid from $target")
+      else
+        cleanup_messages+=("failed to delete $cid from $target")
+        cleanup_failures=$((cleanup_failures + 1))
+      fi
+    done
+    for cid in "${cids[@]:-}"; do
+      if target_delete_cid remote "$cid" >/dev/null 2>&1; then
+        cleanup_messages+=("deleted $cid from remote")
+      else
+        cleanup_messages+=("failed to delete $cid from remote")
+        cleanup_failures=$((cleanup_failures + 1))
+      fi
+    done
+    if [[ "$TEST_KEEP_FILES" != '1' ]]; then
+      rm -rf "$workspace"
+      cleanup_messages+=("removed workspace $workspace")
+    else
+      printf 'kept test workspace: %s\n' "$workspace" >&2
+      cleanup_messages+=("kept workspace $workspace")
+    fi
+  }
+  trap cleanup RETURN
+
+  write_report() {
+    local end_time end_epoch duration i
+    end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    end_epoch="$(date +%s)"
+    duration=$((end_epoch - start_epoch))
+
+    {
+      printf '# Logos Storage Test Report\n\n'
+      printf -- '- **Status:** PASS\n'
+      printf -- "- **Started:** \`%s\`\n" "$start_time"
+      printf -- "- **Finished:** \`%s\`\n" "$end_time"
+      printf -- "- **Duration:** \`%ss\`\n" "$duration"
+      printf -- "- **Target:** \`%s\`\n" "$target"
+      printf -- "- **Remote source:** \`remote\`\n"
+      printf -- "- **File sizes:** \`%s\`\n" "$TEST_FILE_SIZES"
+      printf -- "- **Workspace:** \`%s\`\n" "$workspace"
+      printf -- "- **Cleanup failures:** \`%s\`\n\n" "$cleanup_failures"
+
+      printf '## Files\n\n'
+      printf '| # | Size | Bytes | Manifest Time | Network Stream Time | Network Stream Speed | Local Write Time | Local Write Speed | Total Time | Total Speed | CID | SHA-256 | Source | Download |\n'
+      printf '|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|\n'
+      for i in "${!result_cids[@]}"; do
+        printf "| %d | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` |\n" \
+          "$((i + 1))" \
+          "${result_sizes[$i]}" \
+          "${result_bytes[$i]}" \
+          "${result_manifest_times[$i]}" \
+          "${result_network_times[$i]}" \
+          "${result_network_speeds[$i]}" \
+          "${result_write_times[$i]}" \
+          "${result_write_speeds[$i]}" \
+          "${result_total_times[$i]}" \
+          "${result_total_speeds[$i]}" \
+          "${result_cids[$i]}" \
+          "${result_hashes[$i]}" \
+          "${result_sources[$i]}" \
+          "${result_downloads[$i]}"
+      done
+
+      printf '\n## Cleanup\n\n'
+      if [[ ${#cleanup_messages[@]} -eq 0 ]]; then
+        printf -- '- No cleanup actions recorded.\n'
+      else
+        for i in "${!cleanup_messages[@]}"; do
+          printf -- '- %s\n' "${cleanup_messages[$i]}"
+        done
+      fi
+    } > "$report_path"
+  }
+
+  printf 'Starting Logos Storage remote-to-%s test\n' "$target"
+  printf '  workspace: %s\n' "$workspace"
+  printf '  report:    %s\n' "$report_path"
+  printf '  sizes:     %s\n' "$TEST_FILE_SIZES"
+
+  local size index=0
+  for size in $TEST_FILE_SIZES; do
+    local bytes src out cid src_hash out_hash
+    local manifest_start manifest_end network_start network_end write_start write_end
+    local manifest_seconds network_seconds write_seconds total_seconds
+    local network_speed write_speed total_speed
+    bytes="$(size_to_bytes "$size")"
+    (( bytes <= max_bytes )) || die "test file size exceeds 10MB limit: $size"
+
+    index=$((index + 1))
+    src="${workspace}/source-${index}-${size}.bin"
+    out="${workspace}/download-${index}-${size}.bin"
+    dd if=/dev/urandom of="$src" bs="$size" count=1 status=none
+    src_hash="$(sha256sum "$src" | awk '{ print $1 }')"
+
+    printf '\n[%d] Generate %s random file (%s bytes)\n' "$index" "$size" "$bytes"
+    printf '[%d] Upload to remote\n' "$index"
+    cid="$(target_upload_file remote "$src")"
+    cids+=("$cid")
+
+    printf '[%d] Resolve manifest via %s: %s\n' "$index" "$target" "$cid"
+    manifest_start="$(now_ns)"
+    target_manifest_cid "$target" "$cid"
+    manifest_end="$(now_ns)"
+    manifest_seconds="$(elapsed_seconds "$manifest_start" "$manifest_end")"
+
+    printf '[%d] Network stream via %s\n' "$index" "$target"
+    network_start="$(now_ns)"
+    target_stream_sink "$target" "$cid"
+    network_end="$(now_ns)"
+    network_seconds="$(elapsed_seconds "$network_start" "$network_end")"
+    network_speed="$(format_speed "$bytes" "$network_seconds")"
+    local_cids+=("$cid")
+
+    printf '[%d] Local write via %s\n' "$index" "$target"
+    write_start="$(now_ns)"
+    target_download_local_cid "$target" "$cid" "$out"
+    write_end="$(now_ns)"
+    write_seconds="$(elapsed_seconds "$write_start" "$write_end")"
+    write_speed="$(format_speed "$bytes" "$write_seconds")"
+    total_seconds="$(sum_seconds "$manifest_seconds" "$network_seconds" "$write_seconds")"
+    total_speed="$(format_speed "$bytes" "$total_seconds")"
+
+    out_hash="$(sha256sum "$out" | awk '{ print $1 }')"
+    [[ "$src_hash" == "$out_hash" ]] || die "hash mismatch for cid $cid"
+    result_sizes+=("$size")
+    result_bytes+=("$bytes")
+    result_sources+=("$src")
+    result_downloads+=("$out")
+    result_cids+=("$cid")
+    result_hashes+=("$src_hash")
+    result_manifest_times+=("${manifest_seconds}s")
+    result_network_times+=("${network_seconds}s")
+    result_network_speeds+=("$network_speed")
+    result_write_times+=("${write_seconds}s")
+    result_write_speeds+=("$write_speed")
+    result_total_times+=("${total_seconds}s")
+    result_total_speeds+=("$total_speed")
+    printf '[%d] Manifest:       %ss\n' "$index" "$manifest_seconds"
+    printf '[%d] Network stream: %ss, %s\n' "$index" "$network_seconds" "$network_speed"
+    printf '[%d] Local write:    %ss, %s\n' "$index" "$write_seconds" "$write_speed"
+    printf '[%d] Total:          %ss, %s\n' "$index" "$total_seconds" "$total_speed"
+    printf '[%d] OK sha256=%s\n' "$index" "$src_hash"
+  done
+
+  printf '\nCleaning up remote and %s CIDs...\n' "$target"
+  cleanup
+  trap - RETURN
+  write_report
+
+  printf '\nTest passed\n'
+  printf '  target:           %s\n' "$target"
+  printf '  files validated:  %d\n' "$index"
+  printf '  cleanup failures: %d\n' "$cleanup_failures"
+  printf '  report:           %s\n' "$report_path"
+}
+
+target_command() {
+  local target="$1"
+  local command="${2:-help}"
+  shift 2 || true
+
+  case "$command" in
+    upload) target_upload_file "$target" "${1:-}" ;;
+    upload-random) target_upload_random "$target" "$@" ;;
+    download) target_download_cid "$target" "$@" ;;
+    fetch) target_fetch_cid "$target" "$@" ;;
+    stream-sink) target_stream_sink "$target" "$@" ;;
+    list) [[ $# -eq 0 ]] || die 'list does not accept arguments'; target_list_cids "$target" ;;
+    delete) target_delete_cid "$target" "$@" ;;
+    delete-all) target_delete_all "$target" "$@" ;;
+    exists) target_exists_cid "$target" "$@" ;;
+    space) [[ $# -eq 0 ]] || die 'space does not accept arguments'; target_simple_get "$target" 'space' ;;
+    peerid) [[ $# -eq 0 ]] || die 'peerid does not accept arguments'; target_simple_get "$target" 'peerid' ;;
+    test) [[ $# -eq 0 ]] || die 'test does not accept arguments yet'; target_test "$target" ;;
+    spr|debug|peers|manifest|connect)
+      [[ "$target" == 'lib' ]] || die "$command is currently supported only for lib target"
+      lib_only_command "$command" "$@"
+      ;;
+    help|--help|-h)
+      usage
+      ;;
+    *)
+      die "unknown command for target '$target': $command"
+      ;;
+  esac
+}
+
+cmd="${1:-help}"
+shift || true
+
+if is_target "$cmd"; then
+  target_command "$cmd" "$@"
+  exit 0
+fi
+
+case "$cmd" in
+  help|--help|-h)
+    usage
+    ;;
+  tunnel)
+    case "${1:-}" in
+      start) tunnel_start ;;
+      stop) tunnel_stop ;;
+      status)
+        if tunnel_status; then
+          printf 'tunnel running\n'
+        else
+          printf 'tunnel stopped\n'
+          exit 1
+        fi
+        ;;
+      *) die 'usage: tunnel start|stop|status' ;;
+    esac
+    ;;
+  make-file) make_file "$@" ;;
+  last-cid) last_cid "$@" ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/tools/storage-test/storage-test.sh
+++ b/tools/storage-test/storage-test.sh
@@ -642,7 +642,7 @@ target_test() {
       cleanup_messages+=("kept workspace $workspace")
     fi
   }
-  trap cleanup ERR RETURN
+  trap cleanup ERR
 
   write_report() {
     local end_time end_epoch duration i
@@ -766,7 +766,7 @@ target_test() {
 
   printf '\nCleaning up remote and %s CIDs...\n' "$target"
   cleanup
-  trap - ERR RETURN
+  trap - ERR
   write_report
 
   printf '\nTest passed\n'


### PR DESCRIPTION
>  ## Related PRs
> 
> This is part of the lifecycle simplification across the storage stack:
> 
> - logos-storage-nim: https://github.com/logos-storage/logos-storage-nim/pull/1476 (this PR)
> - logos-storage-module: https://github.com/logos-co/logos-storage-module/pull/64
> - logos-storage-ui: https://github.com/logos-co/logos-storage-ui/pull/54


## Summary

Simplifies the public `libstorage` lifecycle API around a single terminal shutdown operation:

- `storage_new(config)`
- `storage_start(ctx)`
- `storage_shutdown(ctx)`

This replaces the previous public stop/close/destroy choreography and makes context ownership explicit: once `storage_shutdown()` is accepted, `libstorage` owns the context and the caller must not use it again.

## Motivation

The old lifecycle exposed too much internal sequencing to callers:

- `storage_stop`
- `storage_close`
- `storage_destroy`

That made it easy for wrappers to call lifecycle operations from inside callbacks. Since callbacks run on the storage worker thread, chaining calls such as `stop -> close -> destroy` from a callback could block or deadlock against the same worker thread.

`destroyStorageContext()` also joins and frees the storage worker thread, so it must never run from the storage worker thread itself.

## Changes

- Adds `storage_shutdown(ctx, callback, userData)`.
- Removes the old public lifecycle exports for `storage_stop`, `storage_close`, and `storage_destroy`.
- Introduces an internal `SHUTDOWN_NODE` lifecycle request.
- Keeps internal storage shutdown behavior as stop plus close.
- Moves context destruction into a libstorage-owned shutdown supervisor thread.
- Ensures the final shutdown callback is emitted only after the storage context has been stopped, closed, destroyed, and invalidated.
- Updates C headers, C binding tests, README/docs, and helper tooling.
- Updates the C++ wrapper/daemon helper to expose shutdown semantics.

## Threading Model

`storage_shutdown()` now queues shutdown work to a libstorage-owned supervisor thread.

The supervisor:

- dispatches `SHUTDOWN_NODE` to the storage worker thread
- waits for the worker-thread shutdown callback
- calls `destroyStorageContext(ctx)` from outside the storage worker thread
- invokes the user callback after cleanup is complete

This keeps lifecycle cleanup out of libstorage callbacks and avoids joining/freeing the worker thread from itself.

## API Contract

After `storage_shutdown()` returns `RET_OK`:

- ownership of `ctx` has transferred to libstorage
- callers must not use `ctx` again
- the final callback means shutdown is complete and the context is invalid/freed

If `storage_shutdown()` returns an error:

- ownership was not accepted
- the caller still owns the context
