### PR TITLE
chore: require bash 4.0 for storage-config.sh

### DIFF
--- a/tools/scripts/storage-config.sh
+++ b/tools/scripts/storage-config.sh
@@ -4,11 +4,6 @@
 
 set -euo pipefail
 
-# Valid networks
-declare -A _networks
-#_networks=([test]="Logos testnet" [dev]="Logos devnet")
-_networks=([dev]="Logos devnet")
-
 echoerr() {
     echo "[storage_config] $1" >&2
 }
@@ -30,8 +25,15 @@ require() {
             exit 1
         fi
     fi
-    
 }
+
+require jq
+require bash 4
+
+# Valid networks
+declare -A _networks
+#_networks=([test]="Logos testnet" [dev]="Logos devnet")
+_networks=([dev]="Logos devnet")
 
 check_network() {
     local network=$1
@@ -110,9 +112,6 @@ EOF
   }
 EOF
 }
-
-require jq
-require bash 4
 
 usage() {
     cat <<EOF

--- a/tools/scripts/storage-config.sh
+++ b/tools/scripts/storage-config.sh
@@ -14,10 +14,23 @@ echoerr() {
 }
 
 require() {
+    if [[ $# -eq 0 || $# -gt 2 ]]; then
+        echoerr "Usage: require <command>"
+        echoerr "Usage: require <command> <min_version>"
+        exit 1
+    fi
     if ! command -v "$1" &> /dev/null; then
         echoerr "Error: $1 is not installed"
         exit 1
     fi
+    if [[ $# -eq 2 ]]; then
+        ver=$($1 --version | grep -oE '[0-9]+' | head -n1)
+        if [[ $ver -lt $2 ]]; then
+            echoerr "Error: $1 version $2+ is required, but found version $ver"
+            exit 1
+        fi
+    fi
+    
 }
 
 check_network() {
@@ -99,6 +112,7 @@ EOF
 }
 
 require jq
+require bash 4
 
 usage() {
     cat <<EOF


### PR DESCRIPTION
Macos ships with bash 3.2 due to bash licensing that changed with 4.0 (GPLv3). This script uses features available in bash 4+ (eg associative arrays). When bash <4 is used, the following error is reported:
```bash
 ./tools/scripts/storage-config.sh: line 8: declare: -A: invalid option
  declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

This PR adds an explicit `require bash 4` in the script, which produces an error if the dependency version is not met:
```bash
[storage_config] Error: bash version 4+ is required, but found version 3
```