### PR TITLE
chore: better shutdown

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -105,10 +105,9 @@ Typical usage:
 
 ---
 
-> **Restart is not supported.**.
-> `storage_stop` to stop the node and free resource.
-> Use `storage_boot` to start a new instance with a clean state or `storage_new`
-> to create a new instance.
+> **Restart is not supported.** Use `storage_stop` to stop the node and free its
+> resources. To run again, create a fresh instance with `storage_boot` (or
+> `storage_new` + `storage_start`).
 
 ### `storage_start`
 

--- a/library/README.md
+++ b/library/README.md
@@ -143,7 +143,7 @@ int storage_stop(void *ctx, StorageCallback callback, void *userData);
 
 ### `storage_close`
 
-**Deprecated — no-op.** Does nothing, kept for ABI compatibility. Use `storage_stop` to tear
+**Deprecated — no-op.** Does nothing, kept for compatibility. Use `storage_stop` to tear
 the node down before `storage_destroy`.
 
 ```c

--- a/library/README.md
+++ b/library/README.md
@@ -2,10 +2,10 @@
 
 Logos Storage exposes a C binding that serves as a stable contract, making it straightforward to integrate Logos Storage into other languages such as Go.
 
-The implementation was inspired by [nim-library-template](https://github.com/logos-co/nim-library-template)  
+The implementation was inspired by [nim-library-template](https://github.com/logos-co/nim-library-template)
 and by the [nwaku](https://github.com/waku-org/nwaku/tree/master/library) library.
 
-The source code contains detailed comments to explain the threading and callback flow.  
+The source code contains detailed comments to explain the threading and callback flow.
 The diagram below summarizes the lifecycle: context creation, request execution, and shutdown.
 
 ```mermaid
@@ -26,7 +26,7 @@ sequenceDiagram
     Thr->>Ctx: dequeue request
     Thr-->>Ctx: ACK
     Ctx-->>C: forward ACK
-    C-->>Go: RET OK 
+    C-->>Go: RET OK
     Go->>App: Unblock
     Thr->>Eng: execute (async)
     Eng-->>Thr: result ready
@@ -47,7 +47,7 @@ Unless explicitly stated otherwise, all functions are asynchronous and execute t
 - `RET_ERR`: immediate failure
 - `RET_MISSING_CALLBACK`: callback is missing
 
-Some functions may emit progress updates via the callback using `RET_PROGRESS`, and finally complete with `RET_OK` or `RET_ERR`.  
+Some functions may emit progress updates via the callback using `RET_PROGRESS`, and finally complete with `RET_OK` or `RET_ERR`.
 
 The `msg` parameter can carry different kinds of data depending on the return code:
 
@@ -105,9 +105,14 @@ Typical usage:
 
 ---
 
+> **Restart is not supported.**.
+> `storage_stop` to stop the node and free resource.
+> Use `storage_boot` to start a new instance with a clean state or `storage_new`
+> to create a new instance.
+
 ### `storage_start`
 
-Start the Logos Storage node (can be started/stopped multiple times).
+Start a node previously created with `storage_new`. Errors if the node was already stopped.
 
 ```c
 int storage_start(void *ctx, StorageCallback callback, void *userData);
@@ -115,9 +120,20 @@ int storage_start(void *ctx, StorageCallback callback, void *userData);
 
 ---
 
+### `storage_boot`
+
+Create a new context, then create and start the node in one call. A shortcut for
+`storage_new` + `storage_start`; returns the new context.
+
+```c
+void *storage_boot(const char *configJson, StorageCallback callback, void *userData);
+```
+
+---
+
 ### `storage_stop`
 
-Stop the Logos Storage node (can be started/stopped multiple times).
+Stop the Logos Storage node. Terminal: tears the node down. A stopped node cannot be restarted.
 
 ```c
 int storage_stop(void *ctx, StorageCallback callback, void *userData);
@@ -127,7 +143,8 @@ int storage_stop(void *ctx, StorageCallback callback, void *userData);
 
 ### `storage_close`
 
-Close the node and release resources before destruction.
+**Deprecated — no-op.** Does nothing, kept for ABI compatibility. Use `storage_stop` to tear
+the node down before `storage_destroy`.
 
 ```c
 int storage_close(void *ctx, StorageCallback callback, void *userData);
@@ -137,8 +154,8 @@ int storage_close(void *ctx, StorageCallback callback, void *userData);
 
 ### `storage_destroy`
 
-Destroys the node instance and frees associated resources. Node must be stopped and closed.
-The call is synchronous, so it does not require a callback.
+Destroys the node instance and frees associated resources. The node must be stopped
+(`storage_stop`) before calling this. The call is synchronous, so it does not require a callback.
 
 ```c
 int storage_destroy(void *ctx);

--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -378,7 +378,7 @@ extern "C"
                        void *userData);
 
     // Stop the Logos Storage node. This is terminal: it tears the node down
-    // (switch, datastores, taskpool). A stopped node cannot be restarted.
+    // resources. A stopped node cannot be restarted.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);

--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -387,7 +387,7 @@ extern "C"
                        void *userData);
 
     // Stop the Logos Storage node. This is terminal: it tears the node down
-    // resources. A stopped node cannot be restarted.
+    // and frees its resources. A stopped node cannot be restarted.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);

--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -352,8 +352,8 @@ extern "C"
         StorageCallback callback,
         void *userData);
 
-    // Start the Logos Storage node.
-    // The node can be started and stopped multiple times.
+    // Start a Logos Storage node that was created with storage_new.
+    // storage_stop is terminal: once stopped, a node cannot be restarted.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);
@@ -365,8 +365,20 @@ extern "C"
                       StorageCallback callback,
                       void *userData);
 
-    // Stop the Logos Storage node.
-    // The node can be started and stopped multiple times.
+    // Create a new context, then create and start the node in one call.
+    // A shortcut for storage_new + storage_start; returns the new context.
+    //
+    // Typical usage:
+    // ctx = storage_boot(configJson, myCallback, myUserData);
+    // ...
+    // storage_stop(ctx, ...);
+    // storage_destroy(ctx, ...);
+    void *storage_boot(const char *configJson,
+                       StorageCallback callback,
+                       void *userData);
+
+    // Stop the Logos Storage node. This is terminal: it tears the node down
+    // (switch, datastores, taskpool). A stopped node cannot be restarted.
     //
     // Typical usage:
     // ctx = storage_new(configJson, myCallback, myUserData);
@@ -378,22 +390,16 @@ extern "C"
                      StorageCallback callback,
                      void *userData);
 
-    // Close the Logos Storage node.
-    // Use this to release resources before destroying the node.
-    //
-    // Typical usage:
-    // ctx = storage_new(configJson, myCallback, myUserData);
-    // storage_start(ctx, ...);
-    // ...
-    // storage_stop(ctx, ...);
-    // storage_close(ctx, ...);
+    // Deprecated no-op, kept for ABI compatibility. Does nothing.
+    // The node is torn down by storage_stop; call it before storage_destroy.
+    __attribute__((deprecated("no-op; call storage_stop to tear down the node")))
     int storage_close(void *ctx,
                       StorageCallback callback,
                       void *userData);
 
     // Destroys an instance of a Logos Storage node.
     // This will free all resources associated with the node.
-    // The node must be stopped and closed before calling this function.
+    // The node must be stopped (storage_stop) before calling this function.
     // The call is synchronous, so it does not require a callback.
     //
     // Typical usage:
@@ -401,7 +407,6 @@ extern "C"
     // storage_start(ctx, ...);
     // ...
     // storage_stop(ctx, ...);
-    // storage_close(ctx, ...);
     // storage_destroy(ctx, ...);
     int storage_destroy(void *ctx);
 

--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -39,6 +39,15 @@
 // with progress updates.
 #define RET_PROGRESS 3
 
+// Portable deprecation marker (GCC/Clang, MSVC, or no-op elsewhere).
+#if defined(__GNUC__) || defined(__clang__)
+#define STORAGE_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define STORAGE_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define STORAGE_DEPRECATED(msg)
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -392,7 +401,7 @@ extern "C"
 
     // Deprecated no-op, kept for ABI compatibility. Does nothing.
     // The node is torn down by storage_stop; call it before storage_destroy.
-    __attribute__((deprecated("no-op; call storage_stop to tear down the node")))
+    STORAGE_DEPRECATED("no-op; call storage_stop to tear down the node")
     int storage_close(void *ctx,
                       StorageCallback callback,
                       void *userData);

--- a/library/libstorage.nim
+++ b/library/libstorage.nim
@@ -262,17 +262,11 @@ proc storage_peer_debug(
 proc storage_close(
     ctx: ptr StorageContext, callback: StorageCallback, userData: pointer
 ): cint {.dynlib, exportc.} =
+  ## Deprecated no-op: the node is torn down by storage_stop. Kept for ABI compatibility.
   initializeLibrary()
   checkLibstorageParams(ctx, callback, userData)
 
-  let reqContent = NodeLifecycleRequest.createShared(NodeLifecycleMsgType.CLOSE_NODE)
-  var res = storage_context.sendRequestToStorageThread(
-    ctx, RequestType.LIFECYCLE, reqContent, callback, userData
-  )
-  if res.isErr:
-    return callback.error(res.error, userData)
-
-  return callback.okOrError(res, userData)
+  return callback.success("", userData)
 
 proc storage_destroy(ctx: ptr StorageContext): cint {.dynlib, exportc.} =
   initializeLibrary()
@@ -561,6 +555,36 @@ proc storage_start(
   )
 
   return callback.okOrError(res, userData)
+
+proc storage_boot(
+    configJson: cstring, callback: StorageCallback, userData: pointer
+): pointer {.dynlib, exported.} =
+  ## Create a new context, then create and start the node in one call.
+  ## A shortcut for storage_new + storage_start; returns the new context.
+  initializeLibrary()
+
+  if isNil(callback):
+    error "Failed to boot Storage instance: the callback is missing."
+    return nil
+
+  var ctx = storage_context.createStorageContext().valueOr:
+    let msg = $error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return nil
+
+  ctx.userData = userData
+
+  let reqContent =
+    NodeLifecycleRequest.createShared(NodeLifecycleMsgType.BOOT_NODE, configJson)
+
+  storage_context.sendRequestToStorageThread(
+    ctx, RequestType.LIFECYCLE, reqContent, callback, userData
+  ).isOkOr:
+    let msg = $error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return nil
+
+  return ctx
 
 proc storage_stop(
     ctx: ptr StorageContext, callback: StorageCallback, userData: pointer

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -22,7 +22,7 @@ import ../../../storage/utils
 import ../../../storage/utils/[keyutils, fileutils]
 import ../../../storage/units
 
-from ../../../storage/storage import StorageServer, new, start, stop, close
+from ../../../storage/storage import StorageServer, new, start, shutdown
 
 logScope:
   topics = "libstorage libstoragelifecycle"
@@ -32,8 +32,8 @@ const LibstorageDisableRestApi* {.booldefine.} = true
 type NodeLifecycleMsgType* = enum
   CREATE_NODE
   START_NODE
+  BOOT_NODE
   STOP_NODE
-  CLOSE_NODE
 
 proc readValue*[T: InputFile | InputDir | OutPath | OutDir | OutFile](
     r: var JsonReader, val: var T
@@ -184,16 +184,20 @@ proc process*(
     except Exception as e:
       error "Failed to START_NODE.", error = e.msg
       return err(e.msg)
+  of BOOT_NODE:
+    # storage_boot runs on a fresh context, so create the node then start it.
+    try:
+      storage[] = (await createStorage(self.configJson)).valueOr:
+        error "Failed to BOOT_NODE.", error = error
+        return err($error)
+      await storage[].start()
+    except Exception as e:
+      error "Failed to BOOT_NODE.", error = e.msg
+      return err(e.msg)
   of STOP_NODE:
     try:
-      await storage[].stop()
+      await storage[].shutdown()
     except Exception as e:
       error "Failed to STOP_NODE.", error = e.msg
-      return err(e.msg)
-  of CLOSE_NODE:
-    try:
-      await storage[].close()
-    except Exception as e:
-      error "Failed to CLOSE_NODE.", error = e.msg
       return err(e.msg)
   return ok("")

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -159,10 +159,8 @@ proc start*(s: StorageServer) {.async.} =
 
   s.isStarted = true
 
-# The libp2p Switch cannot be restarted once stopped (its ConnManager is closed
-# permanently), so there is no meaningful start/stop cycle: shutting down is
-# terminal. `stop` and `close` are intentionally not exposed separately; the only
-# teardown path is a single, one-shot `shutdown`.
+# Stop the node and close all resources.
+# The node cannot be restarted after shutdown, a new instance must be created.
 proc shutdown*(s: StorageServer) {.async.} =
   if s.isShutdown:
     warn "Storage already shut down"
@@ -184,10 +182,6 @@ proc shutdown*(s: StorageServer) {.async.} =
   let stopRes = await noCancel allDone[void](stopFutures)
   s.isStarted = false
 
-  # storageNode.close() already closes the repoStore (via networkStore.localStore),
-  # so we must not close it again here: two concurrent closes on the same LevelDB
-  # leave it in an inconsistent state and blocks written before the close are lost
-  # on the next open (breaks storage_boot on the same data-dir).
   let closeRes = await noCancel allDone[void](
     @[s.storageNode.close(), s.storageNode.discovery.close()]
   )

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -169,22 +169,31 @@ proc shutdown*(s: StorageServer) {.async.} =
 
   notice "Stopping Storage node"
 
-  var stopFutures = @[
-    s.storageNode.switch.stop(),
-    s.storageNode.stop(),
-    s.repoStore.stop(),
-    s.maintenance.stop(),
-  ]
+  var failures: seq[string]
+  var cancellations = 0
 
-  if s.restServer != nil:
-    stopFutures.add(s.restServer.stop())
+  if s.isStarted:
+    var stopFutures = @[
+      s.storageNode.switch.stop(),
+      s.storageNode.stop(),
+      s.repoStore.stop(),
+      s.maintenance.stop(),
+    ]
 
-  let stopRes = await noCancel allDone[void](stopFutures)
-  s.isStarted = false
+    if s.restServer != nil:
+      stopFutures.add(s.restServer.stop())
 
+    let stopRes = await noCancel allDone[void](stopFutures)
+    s.isStarted = false
+    failures.add(stopRes.failed.mapIt(it.error.msg))
+    cancellations += stopRes.cancelled.len
+
+  # Close resources created by new() regardless of whether the node started.
   let closeRes = await noCancel allDone[void](
     @[s.storageNode.close(), s.storageNode.discovery.close()]
   )
+  failures.add(closeRes.failed.mapIt(it.error.msg))
+  cancellations += closeRes.cancelled.len
 
   if not s.taskpool.isNil:
     s.taskpool.shutdown()
@@ -199,22 +208,19 @@ proc shutdown*(s: StorageServer) {.async.} =
     if error =? closeFile(s.logFile.get()).errorOption:
       error "Failed to close log file", errorCode = $error
 
-  let failed = stopRes.failed & closeRes.failed
-  if failed.len > 0:
-    error "Failed to shut down Storage node", failures = failed.len
+  if failures.len > 0:
+    error "Failed to shut down Storage node", failures = failures.len
     raise newException(
-      StorageError,
-      "Failed to shut down Storage node: " & failed.mapIt(it.error.msg).join(", "),
+      StorageError, "Failed to shut down Storage node: " & failures.join(", ")
     )
 
-  let cancelled = stopRes.cancelled.len + closeRes.cancelled.len
-  if cancelled > 0:
+  if cancellations > 0:
     warn "Storage node shutdown was cancelled due to child routine(s) being cancelled",
-      cancellations = cancelled
+      cancellations = cancellations
     raise newException(
       CancelledError,
       "Storage node shutdown was cancelled due to child routine(s) being cancelled: " &
-        $cancelled,
+        $cancellations,
     )
 
 proc new*(

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -55,6 +55,7 @@ type
     maintenance: BlockMaintainer
     taskpool: Taskpool
     isStarted: bool
+    isShutdown: bool
 
   StoragePrivateKey* = libp2p.PrivateKey # alias
 
@@ -68,6 +69,11 @@ func repoStore*(self: StorageServer): RepoStore =
   return self.repoStore
 
 proc start*(s: StorageServer) {.async.} =
+  if s.isShutdown:
+    raise newException(
+      StorageError,
+      "Storage has been shut down and cannot be restarted; create a new instance",
+    )
   if s.isStarted:
     warn "Storage server already started, skipping"
     return
@@ -153,14 +159,19 @@ proc start*(s: StorageServer) {.async.} =
 
   s.isStarted = true
 
-proc stop*(s: StorageServer) {.async.} =
-  if not s.isStarted:
-    warn "Storage is not started"
+# The libp2p Switch cannot be restarted once stopped (its ConnManager is closed
+# permanently), so there is no meaningful start/stop cycle: shutting down is
+# terminal. `stop` and `close` are intentionally not exposed separately; the only
+# teardown path is a single, one-shot `shutdown`.
+proc shutdown*(s: StorageServer) {.async.} =
+  if s.isShutdown:
+    warn "Storage already shut down"
     return
+  s.isShutdown = true
 
   notice "Stopping Storage node"
 
-  var futures = @[
+  var stopFutures = @[
     s.storageNode.switch.stop(),
     s.storageNode.stop(),
     s.repoStore.stop(),
@@ -168,32 +179,18 @@ proc stop*(s: StorageServer) {.async.} =
   ]
 
   if s.restServer != nil:
-    futures.add(s.restServer.stop())
+    stopFutures.add(s.restServer.stop())
 
-  let res = await noCancel allDone[void](futures)
-
+  let stopRes = await noCancel allDone[void](stopFutures)
   s.isStarted = false
 
-  if res.failed.len > 0:
-    error "Failed to stop Storage node", failures = res.failed.len
-    raise newException(
-      StorageError,
-      "Failed to stop Storage node: " & res.failed.mapIt(it.error.msg).join(", "),
-    )
-  if res.cancelled.len > 0:
-    warn "Storage node stop was cancelled due to child stop routine(s) being cancelled, child routines cancelled: ",
-      cancellations = res.cancelled.len
-    raise newException(
-      CancelledError,
-      "Storage node stop was cancelled due to child stop routine(s) being cancelled, child routines cancelled: " &
-        $res.cancelled.len,
-    )
-
-proc close*(s: StorageServer) {.async.} =
-  var futures =
-    @[s.storageNode.close(), s.repoStore.close(), s.storageNode.discovery.close()]
-
-  let res = await noCancel allDone[void](futures)
+  # storageNode.close() already closes the repoStore (via networkStore.localStore),
+  # so we must not close it again here: two concurrent closes on the same LevelDB
+  # leave it in an inconsistent state and blocks written before the close are lost
+  # on the next open (breaks storage_boot on the same data-dir).
+  let closeRes = await noCancel allDone[void](
+    @[s.storageNode.close(), s.storageNode.discovery.close()]
+  )
 
   if not s.taskpool.isNil:
     s.taskpool.shutdown()
@@ -208,24 +205,23 @@ proc close*(s: StorageServer) {.async.} =
     if error =? closeFile(s.logFile.get()).errorOption:
       error "Failed to close log file", errorCode = $error
 
-  if res.failed.len > 0:
-    error "Failed to close Storage node", failures = res.failed.len
+  let failed = stopRes.failed & closeRes.failed
+  if failed.len > 0:
+    error "Failed to shut down Storage node", failures = failed.len
     raise newException(
       StorageError,
-      "Failed to close Storage node: " & res.failed.mapIt(it.error.msg).join(", "),
-    )
-  if res.cancelled.len > 0:
-    warn "Storage node close was cancelled due to child close routine(s) being cancelled, child routines cancelled: ",
-      cancellations = res.cancelled.len
-    raise newException(
-      CancelledError,
-      "Storage node close was cancelled due to child close routine(s) being cancelled, child routines cancelled: " &
-        $res.cancelled.len,
+      "Failed to shut down Storage node: " & failed.mapIt(it.error.msg).join(", "),
     )
 
-proc shutdown*(server: StorageServer) {.async.} =
-  await server.stop()
-  await server.close()
+  let cancelled = stopRes.cancelled.len + closeRes.cancelled.len
+  if cancelled > 0:
+    warn "Storage node shutdown was cancelled due to child routine(s) being cancelled",
+      cancellations = cancelled
+    raise newException(
+      CancelledError,
+      "Storage node shutdown was cancelled due to child routine(s) being cancelled: " &
+        $cancelled,
+    )
 
 proc new*(
     T: type StorageServer,

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -351,6 +351,24 @@ int stop_node(void *storage_ctx)
     return is_resp_ok(r, NULL);
 }
 
+int check_start_after_stop_errors(void *storage_ctx)
+{
+    Resp *r = alloc_resp();
+
+    if (storage_start(storage_ctx, (StorageCallback)callback, r) != RET_OK)
+    {
+        free_resp(r);
+        return RET_OK;
+    }
+
+    wait_resp(r);
+    int ret = get_ret(r);
+    free_resp(r);
+
+    // We expect RET_ERR: a stopped node cannot be restarted.
+    return (ret == RET_ERR) ? RET_OK : RET_ERR;
+}
+
 // storage_boot creates a NEW context, then creates and starts the node.
 // The old context (already stopped) is destroyed first.
 int boot(void **storage_ctx)
@@ -1009,6 +1027,7 @@ int main(void)
     // Stop the node and create a new context with storage_boot,
     // then check that the block is still retrievable.
     RUN_TEST(stop_node(storage_ctx));
+    RUN_TEST(check_start_after_stop_errors(storage_ctx));
     RUN_TEST(boot(&storage_ctx));
     RUN_TEST(check_peer_id(storage_ctx));
     RUN_TEST(check_download_stream(storage_ctx, cid, "downloaded_hello.txt"));

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -404,6 +404,41 @@ int boot(void **storage_ctx)
     return RET_OK;
 }
 
+// Stopping without starting should not crash.
+int check_stop_without_start(void)
+{
+    Resp *r = alloc_resp();
+    const char *cfg =
+        "{\"log-level\":\"WARN\",\"data-dir\":\"./data-dir-nostart\"}";
+
+    void *ctx = storage_new(cfg, (StorageCallback)callback, r);
+    if (!ctx)
+    {
+        free_resp(r);
+        return RET_ERR;
+    }
+
+    // Wait for CREATE_NODE to complete.
+    if (is_resp_ok(r, NULL) != RET_OK)
+    {
+        storage_destroy(ctx);
+        return RET_ERR;
+    }
+
+    // Stop without ever starting: must not crash and must report OK.
+    r = alloc_resp();
+    if (storage_stop(ctx, (StorageCallback)callback, r) != RET_OK)
+    {
+        free_resp(r);
+        storage_destroy(ctx);
+        return RET_ERR;
+    }
+    int ret = is_resp_ok(r, NULL);
+
+    storage_destroy(ctx);
+    return ret;
+}
+
 int cleanup(void *storage_ctx)
 {
     Resp *r = alloc_resp();
@@ -998,6 +1033,7 @@ int main(void)
     BEGIN_SUITE
 
     RUN_TEST(setup(&storage_ctx));
+    RUN_TEST(check_stop_without_start());
     RUN_TEST(check_version(storage_ctx));
     RUN_TEST(start(storage_ctx));
     RUN_TEST(check_repo(storage_ctx));

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -394,6 +394,7 @@ int boot(void **storage_ctx)
 
     if (get_ret(r) != RET_OK)
     {
+        storage_destroy(ctx);
         free_resp(r);
         return RET_ERR;
     }

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -338,26 +338,58 @@ int start(void *storage_ctx)
     return is_resp_ok(r, NULL);
 }
 
-int cleanup(void *storage_ctx)
+int stop_node(void *storage_ctx)
 {
     Resp *r = alloc_resp();
 
-    // Stop node
     if (storage_stop(storage_ctx, (StorageCallback)callback, r) != RET_OK)
     {
         free_resp(r);
         return RET_ERR;
     }
 
-    if (is_resp_ok(r, NULL) != RET_OK)
+    return is_resp_ok(r, NULL);
+}
+
+// storage_boot creates a NEW context, then creates and starts the node.
+// The old context (already stopped) is destroyed first.
+int boot(void **storage_ctx)
+{
+    if (*storage_ctx != NULL)
     {
+        storage_destroy(*storage_ctx);
+        *storage_ctx = NULL;
+    }
+
+    Resp *r = alloc_resp();
+    const char *cfg = "{\"log-level\":\"WARN\",\"data-dir\":\"./data-dir\"}";
+
+    void *ctx = storage_boot(cfg, (StorageCallback)callback, r);
+    if (!ctx)
+    {
+        free_resp(r);
         return RET_ERR;
     }
 
-    r = alloc_resp();
+    wait_resp(r);
 
-    // Close node
-    if (storage_close(storage_ctx, (StorageCallback)callback, r) != RET_OK)
+    if (get_ret(r) != RET_OK)
+    {
+        free_resp(r);
+        return RET_ERR;
+    }
+
+    *storage_ctx = ctx;
+    free_resp(r);
+    return RET_OK;
+}
+
+int cleanup(void *storage_ctx)
+{
+    Resp *r = alloc_resp();
+
+    // Stop node
+    if (storage_stop(storage_ctx, (StorageCallback)callback, r) != RET_OK)
     {
         free_resp(r);
         return RET_ERR;
@@ -973,6 +1005,14 @@ int main(void)
     RUN_TEST(check_list(storage_ctx));
     RUN_TEST(check_space(storage_ctx));
     RUN_TEST(check_exists(storage_ctx, cid, true));
+
+    // Stop the node and create a new context with storage_boot,
+    // then check that the block is still retrievable.
+    RUN_TEST(stop_node(storage_ctx));
+    RUN_TEST(boot(&storage_ctx));
+    RUN_TEST(check_peer_id(storage_ctx));
+    RUN_TEST(check_download_stream(storage_ctx, cid, "downloaded_hello.txt"));
+
     RUN_TEST(check_delete(storage_ctx, cid));
     RUN_TEST(check_exists(storage_ctx, cid, false));
 
@@ -981,6 +1021,7 @@ int main(void)
     RUN_TEST(check_toggle_private_queries(storage_ctx));
     RUN_TEST(update_log_level(storage_ctx, "TRACE"));
     RUN_TEST(check_get_metrics(storage_ctx));
+
     RUN_TEST(cleanup(storage_ctx));
 
     END_SUITE

--- a/tests/cbindings/storage.c
+++ b/tests/cbindings/storage.c
@@ -355,10 +355,11 @@ int check_start_after_stop_errors(void *storage_ctx)
 {
     Resp *r = alloc_resp();
 
+    // Dispatch itself should succeed; the refusal comes via the callback.
     if (storage_start(storage_ctx, (StorageCallback)callback, r) != RET_OK)
     {
         free_resp(r);
-        return RET_OK;
+        return RET_ERR;
     }
 
     wait_resp(r);


### PR DESCRIPTION
This PR introduces a better shutdown process.

### Context

1. In `storage.nim`, we call [`build`](https://github.com/logos-storage/logos-storage-nim/blob/1302a4c0a35e2a212a6b65b4acc6cb1ee462378e/storage/storage.nim#L229-L241) on the `SwitchBuilder` when creating a new `StorageServer`.
2. The [`connManager` is initialised in this `build` function](https://github.com/vacp2p/nim-libp2p/blob/c43199378f46d0aaf61be1cad1ee1d63e8f665d6/libp2p/builders.nim#L469).
3. When we stop the switch, the [`connManager`](https://github.com/vacp2p/nim-libp2p/blob/c43199378f46d0aaf61be1cad1ee1d63e8f665d6/libp2p/switch.nim#L327) is closed.
4. But it is never restarted in the [`start` function](https://github.com/vacp2p/nim-libp2p/blob/c43199378f46d0aaf61be1cad1ee1d63e8f665d6/libp2p/switch.nim#L343-L376).

Moreover, looking into the tests, I didn't find any usage of a switch being restarted. So we cannot support a `restart` process for our node.

### Changes

For the reason given above, this PR introduces a `shutdown` function that stops and closes the resources. It is unified into a single function so as not to suggest that the node can be restarted.

On the `libstorage` side, the `close` function is deprecated and is now a `no-op`, and the `stop` operation calls `shutdown`. Additionally, a new function `boot` is introduced as a shortcut for `create` + `start`.

This PR introduces no breaking changes.