### PR TITLE
feat: add dataset usage by type

### DIFF
--- a/library/libstorage.h
+++ b/library/libstorage.h
@@ -321,7 +321,10 @@ extern "C"
     //  "totalBlocks": 100000,
     //  "quotaMaxBytes": 0,
     //  "quotaUsedBytes": 0,
-    //  "quotaReservedBytes": 0
+    //  "quotaReservedBytes": 0,
+    //  "usage": [
+    //   { "mimetype": "video/mp4", "bytesLocal": 1536, "count": 2 }
+    //  ]
     // }
     int storage_space(
         void *ctx,

--- a/library/storage_thread_requests/requests/node_storage_request.nim
+++ b/library/storage_thread_requests/requests/node_storage_request.nim
@@ -8,8 +8,6 @@
 ## - SPACE: get the amount of space used by the local node.
 ## - EXISTS: check the existence of a cid in a node (local store).
 
-import std/tables
-
 import chronos
 import chronicles
 import serde/json as serde

--- a/library/storage_thread_requests/requests/node_storage_request.nim
+++ b/library/storage_thread_requests/requests/node_storage_request.nim
@@ -8,6 +8,8 @@
 ## - SPACE: get the amount of space used by the local node.
 ## - EXISTS: check the existence of a cid in a node (local store).
 
+import std/tables
+
 import chronos
 import chronicles
 import serde/json as serde
@@ -18,7 +20,8 @@ import ../../../storage/stores/repostore
 
 from ../../../storage/storage import StorageServer, node, repoStore
 from ../../../storage/node import
-  iterateManifests, fetchManifest, fetchDatasetAsyncTask, delete, hasLocalBlock
+  iterateManifests, fetchManifest, fetchDatasetAsyncTask, delete, hasLocalBlock,
+  datasetUsageByType, DatasetTypeUsage
 from libp2p import Cid, init, `$`
 
 logScope:
@@ -35,11 +38,17 @@ type NodeStorageRequest* = object
   operation: NodeStorageMsgType
   cid: cstring
 
+type DatasetUsageEntry = object
+  mimetype {.serialize.}: string
+  bytesLocal {.serialize.}: NBytes
+  count {.serialize.}: int
+
 type StorageSpace = object
   totalBlocks* {.serialize.}: Natural
   quotaMaxBytes* {.serialize.}: NBytes
   quotaUsedBytes* {.serialize.}: NBytes
   quotaReservedBytes* {.serialize.}: NBytes
+  usage* {.serialize.}: seq[DatasetUsageEntry]
 
 proc createShared*(
     T: type NodeStorageRequest, op: NodeStorageMsgType, cid: cstring = ""
@@ -119,11 +128,27 @@ proc space(
     storage: ptr StorageServer
 ): Future[Result[string, string]] {.async: (raises: []).} =
   let repoStore = storage[].repoStore
+  let node = storage[].node
+
+  var usageList: seq[DatasetUsageEntry]
+  try:
+    let usageRes = await node.datasetUsageByType()
+    if usageRes.isErr:
+      return err("Failed to get space usage: " & usageRes.error.msg)
+
+    for mimetype, entry in usageRes.get:
+      usageList.add DatasetUsageEntry(
+        mimetype: mimetype, bytesLocal: entry.bytesLocal, count: entry.count
+      )
+  except CancelledError:
+    return err("Failed to get space usage: cancelled operation.")
+
   let space = StorageSpace(
     totalBlocks: repoStore.totalBlocks,
     quotaMaxBytes: repoStore.quotaMaxBytes,
     quotaUsedBytes: repoStore.quotaUsedBytes,
     quotaReservedBytes: repoStore.quotaReservedBytes,
+    usage: usageList,
   )
   return ok(serde.toJson(space))
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -230,6 +230,25 @@ components:
           description: "The original mimetype of the uploaded content (optional)"
           example: image/png
 
+    DatasetTypeUsage:
+      type: object
+      required:
+        - mimetype
+        - bytesLocal
+        - count
+      properties:
+        mimetype:
+          type: string
+          description: "Mimetype of the datasets ('unknown' when the mimetype is absent)."
+          example: "video/mp4"
+        bytesLocal:
+          type: integer
+          format: int64
+          description: "Total bytes of the datasets stored locally for this mimetype."
+        count:
+          type: integer
+          description: "Number of datasets stored locally for this mimetype."
+
     Space:
       type: object
       required:
@@ -237,6 +256,7 @@ components:
         - quotaMaxBytes
         - quotaUsedBytes
         - quotaReservedBytes
+        - usage
       properties:
         totalBlocks:
           description: "Number of blocks stored by the node"
@@ -254,6 +274,11 @@ components:
           type: integer
           format: int64
           description: "Amount of storage reserved (in bytes) in the Logos Storage's local repository for future use when storage requests will be picked up and hosted by the node using node's availabilities. This does not include the storage currently in use."
+        usage:
+          type: array
+          items:
+            $ref: "#/components/schemas/DatasetTypeUsage"
+          description: "Datasets stored locally, one entry per mimetype ('unknown' when the mimetype is absent)."
 
 servers:
   - url: "http://localhost:8080/api/storage/v1"

--- a/storage/node.nim
+++ b/storage/node.nim
@@ -12,12 +12,14 @@
 import std/options
 import std/sequtils
 import std/strformat
+import std/tables
 import times
 
 import pkg/taskpools
 import pkg/questionable
 import pkg/questionable/results
 import pkg/chronos
+import pkg/serde/json
 
 import pkg/libp2p/[switch, multicodec, multihash]
 import pkg/libp2p/stream/bufferstream
@@ -36,6 +38,7 @@ import ./blockexchange
 import ./streams
 import ./discovery
 import ./utils
+import ./units
 import ./errors
 import ./logutils
 import ./utils/safeasynciter
@@ -449,6 +452,51 @@ proc iterateManifests*(self: StorageNodeRef, onManifest: OnManifest) {.async.} =
         return
 
       onManifest(cid, manifest)
+
+type DatasetTypeUsage* {.serialize.} = object
+  bytesLocal*: NBytes
+  count*: int
+
+proc datasetUsageByType*(
+    self: StorageNodeRef
+): Future[?!Table[string, DatasetTypeUsage]] {.async: (raises: [CancelledError]).} =
+  var usage = initTable[string, DatasetTypeUsage]()
+
+  without cidsIter =? await self.networkStore.listBlocks(BlockType.Manifest), err:
+    return failure(err)
+
+  for c in cidsIter:
+    if cid =? await c:
+      without blk =? await self.networkStore.getBlock(cid), err:
+        warn "Failed to get manifest block by cid", cid
+        continue
+
+      without manifest =? Manifest.decode(blk), err:
+        warn "Failed to decode manifest", cid
+        continue
+
+      let store = self.networkStore.localStore
+
+      without hasFirst =? await store.hasBlock(manifest.treeCid, 0), err:
+        warn "Failed to check first block", cid, err = err.msg
+        continue
+
+      without hasLast =? await store.hasBlock(
+        manifest.treeCid, manifest.blocksCount - 1
+      ), err:
+        warn "Failed to check last block", cid, err = err.msg
+        continue
+
+      if not (hasFirst and hasLast):
+        continue
+
+      let mimetype = if manifest.mimetype.isSome: manifest.mimetype.get else: "unknown"
+      var entry = usage.getOrDefault(mimetype)
+      entry.bytesLocal += manifest.datasetSize
+      entry.count += 1
+      usage[mimetype] = entry
+
+  success(usage)
 
 proc togglePrivateQueries*(self: StorageNodeRef, enable: bool): ?!bool =
   self.discovery.togglePrivateQueries(enable)

--- a/storage/rest/api.nim
+++ b/storage/rest/api.nim
@@ -12,7 +12,6 @@
 import std/sequtils
 import std/mimetypes
 import std/os
-import std/tables
 
 import pkg/questionable
 import pkg/questionable/results

--- a/storage/rest/api.nim
+++ b/storage/rest/api.nim
@@ -12,6 +12,7 @@
 import std/sequtils
 import std/mimetypes
 import std/os
+import std/tables
 
 import pkg/questionable
 import pkg/questionable/results
@@ -469,11 +470,23 @@ proc initDataApi(node: StorageNodeRef, repoStore: RepoStore, router: var RestRou
     return RestApiResponse.response($json, contentType = "application/json")
 
   router.api(MethodGet, "/api/storage/v1/space") do() -> RestApiResponse:
+    without usage =? (await node.datasetUsageByType()), err:
+      return RestApiResponse.error(
+        Http500, "Error when trying to get dataset usage: " & err.msg
+      )
+
+    var usageList: seq[RestDatasetTypeUsage]
+    for mimetype, entry in usage:
+      usageList.add RestDatasetTypeUsage(
+        mimetype: mimetype, bytesLocal: entry.bytesLocal, count: entry.count
+      )
+
     let json = %RestRepoStore(
       totalBlocks: repoStore.totalBlocks,
       quotaMaxBytes: repoStore.quotaMaxBytes,
       quotaUsedBytes: repoStore.quotaUsedBytes,
       quotaReservedBytes: repoStore.quotaReservedBytes,
+      usage: usageList,
     )
     return RestApiResponse.response($json, contentType = "application/json")
 

--- a/storage/rest/json.nim
+++ b/storage/rest/json.nim
@@ -45,11 +45,17 @@ type
   RestNodeId* = object
     id*: NodeId
 
+  RestDatasetTypeUsage* = object
+    mimetype* {.serialize.}: string
+    bytesLocal* {.serialize.}: NBytes
+    count* {.serialize.}: int
+
   RestRepoStore* = object
     totalBlocks* {.serialize.}: Natural
     quotaMaxBytes* {.serialize.}: NBytes
     quotaUsedBytes* {.serialize.}: NBytes
     quotaReservedBytes* {.serialize.}: NBytes
+    usage* {.serialize.}: seq[RestDatasetTypeUsage]
 
   VersionInfo* = object
     version* {.serialize.}: string

--- a/tests/integration/5_minutes/testrestapi.nim
+++ b/tests/integration/5_minutes/testrestapi.nim
@@ -40,6 +40,18 @@ twonodessuite "REST API":
     check response.status == 200
     check (await response.body) != ""
 
+  test "space reports dataset usage grouped by mimetype", twoNodesConfig:
+    let headers = @[("Content-Type", "text/plain")]
+    let response = await client1.uploadRaw("some file contents", headers)
+    check response.status == 200
+
+    let space = (await client1.space()).get
+    let usage = space.usage.filterIt(it.mimetype == "text/plain")
+
+    check usage.len == 1
+    check usage[0].count == 1
+    check usage[0].bytesLocal > 0'nb
+
   test "node accepts file uploads with content disposition", twoNodesConfig:
     let headers = @[("Content-Disposition", "attachment; filename=\"example.txt\"")]
     let response = await client1.uploadRaw("some file contents", headers)

--- a/tests/integration/storageclient.nim
+++ b/tests/integration/storageclient.nim
@@ -220,6 +220,17 @@ proc list*(
 
   RestContentList.fromJson(await response.body)
 
+proc space*(
+    client: StorageClient
+): Future[?!RestRepoStore] {.async: (raises: [CancelledError, HttpError]).} =
+  let url = client.baseurl & "/space"
+  let response = await client.get(url)
+
+  if response.status != 200:
+    return failure($response.status)
+
+  RestRepoStore.fromJson(await response.body)
+
 proc hasBlock*(
     client: StorageClient, cid: Cid
 ): Future[?!bool] {.async: (raises: [CancelledError, HttpError]).} =

--- a/tests/storage/helpers.nim
+++ b/tests/storage/helpers.nim
@@ -82,13 +82,13 @@ proc testManifestDesc*(
   ManifestDescriptor(manifest: manifest, manifestCid: Cid.example)
 
 proc storeDataGetManifest*(
-    store: BlockStore, blocks: seq[Block]
+    store: BlockStore, blocks: seq[Block], mimetype: Option[string] = string.none
 ): Future[ManifestDescriptor] {.async.} =
   for blk in blocks:
     (await store.putBlock(blk)).tryGet()
 
   let
-    (_, tree, manifest, manifestCid) = makeDataset(blocks).tryGet()
+    (_, tree, manifest, manifestCid) = makeDataset(blocks, mimetype).tryGet()
     treeCid = tree.rootCid.tryGet()
     manifestBlock =
       Block.new(manifest.encode().tryGet(), codec = ManifestCodec).tryGet()

--- a/tests/storage/helpers/datasetutils.nim
+++ b/tests/storage/helpers/datasetutils.nim
@@ -34,7 +34,9 @@ proc makeRandomBlocks*(
 
     result.add(Block.new(chunk).tryGet())
 
-proc makeDataset*(blocks: seq[Block]): ?!TestDataset =
+proc makeDataset*(
+    blocks: seq[Block], mimetype: Option[string] = string.none
+): ?!TestDataset =
   if blocks.len == 0:
     return failure("Blocks list was empty")
 
@@ -47,6 +49,7 @@ proc makeDataset*(blocks: seq[Block]): ?!TestDataset =
       treeCid = treeCid,
       blockSize = NBytes(blockSize),
       datasetSize = NBytes(datasetSize),
+      mimetype = mimetype,
     )
     manifestBlock = ?Block.new(?manifest.encode(), codec = ManifestCodec)
 

--- a/tests/storage/node/testnode.nim
+++ b/tests/storage/node/testnode.nim
@@ -1,6 +1,8 @@
 import std/os
 import std/math
+import std/options
 import std/importutils
+import std/tables
 
 import pkg/chronos
 import pkg/stew/byteutils
@@ -248,3 +250,58 @@ asyncchecksuite "Test Node - Basic":
       expiry = SecondsSince1970(9999999999)
     let res = await node.updateExpiry(manifestBlk.cid, expiry)
     check res.isErr
+
+asyncchecksuite "Test Node - Usage by type":
+  setupAndTearDown()
+
+  setup:
+    await node.start()
+
+  test "get fully-downloaded datasets grouped by mimetype":
+    let largeBlocks = await makeRandomBlocks(datasetSize = 1024, blockSize = 256'nb)
+    discard await storeDataGetManifest(localStore, largeBlocks, some("video/mp4"))
+
+    let mediumBlocks = await makeRandomBlocks(datasetSize = 512, blockSize = 256'nb)
+    discard await storeDataGetManifest(localStore, mediumBlocks, some("video/mp4"))
+
+    let smallBlocks = await makeRandomBlocks(datasetSize = 768, blockSize = 256'nb)
+    discard await storeDataGetManifest(localStore, smallBlocks, some("image/png"))
+
+    let usage = (await node.datasetUsageByType()).tryGet()
+
+    check:
+      usage["video/mp4"].bytesLocal == 1024'nb + 512'nb
+      usage["video/mp4"].count == 2
+      usage["image/png"].bytesLocal == 768'nb
+      usage["image/png"].count == 1
+
+  test "datasets without a mimetype are grouped under 'unknown'":
+    let blocks = await makeRandomBlocks(datasetSize = 1024, blockSize = 256'nb)
+    discard await storeDataGetManifest(localStore, blocks, string.none)
+
+    let usage = (await node.datasetUsageByType()).tryGet()
+    check:
+      usage["unknown"].bytesLocal == 1024'nb
+      usage["unknown"].count == 1
+
+  test "excludes a dataset missing its last block":
+    let blocks = await makeRandomBlocks(datasetSize = 1024, blockSize = 256'nb)
+    let md = await storeDataGetManifest(localStore, blocks, some("video/mp4"))
+    (await localStore.delBlock(md.manifest.treeCid, md.manifest.blocksCount - 1)).tryGet()
+
+    let usage = (await node.datasetUsageByType()).tryGet()
+    check "video/mp4" notin usage
+
+  test "excludes a dataset missing its first block":
+    let blocks = await makeRandomBlocks(datasetSize = 1024, blockSize = 256'nb)
+    let md = await storeDataGetManifest(localStore, blocks, some("video/mp4"))
+    (await localStore.delBlock(md.manifest.treeCid, 0)).tryGet()
+
+    let usage = (await node.datasetUsageByType()).tryGet()
+    check "video/mp4" notin usage
+
+  test "excludes an existing manifest with no data":
+    discard (await node.storeManifest(Manifest.example)).tryGet()
+
+    let usage = (await node.datasetUsageByType()).tryGet()
+    check usage.len == 0


### PR DESCRIPTION
## Description

This PR enhances the `space` API to add data usage by type. This can be seen as an experimental feature and it is needed for the Storage UI (Disk widget).

## Problem

The problem we currently have with the repo store is that we cannot easily access this information: data is stored as raw blocks, and the repo store keeps no per-type breakdown. The type lives in the manifest, so the usage has to be reconstructed from there.

## Changes

A new method `datasetUsageByType` is introduced. It loops over the manifests and checks the first and last blocks. If they are present, the data is considered part of the repo storage and added to the data usage returned by the function.

We don't want to loop over all the blocks because the API could be very costly in terms of performance.

It has some trade-offs. For example, an aborted dataset may have its first and last block in the repo store while missing blocks in the middle, so it would still be counted in the usage.

But this seems good enough as an `experimental` feature and showcases the space usage by type in the UI.