### PR TITLE
chore: bump nixpkgs to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
         "repo": "nixpkgs",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Logos Storage build flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    # A commit from nixpkgs 25.11 release: https://github.com/NixOS/nixpkgs/tree/release-25.11
+    nixpkgs.url = "github:NixOS/nixpkgs/535f3e6942cb1cead3929c604320d3db54b542b9";
   };
 
   outputs = { self, nixpkgs }:
@@ -39,7 +40,7 @@
             packages.${system}.libstorage
           ];
           # Not using buildInputs to override fakeGit and fakeCargo.
-          nativeBuildInputs = with pkgs; [ git cargo nodejs_18 ];
+          nativeBuildInputs = with pkgs; [ git cargo nodejs_20 ];
         };
       });
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,7 @@ let
   tools = callPackage ./tools.nix {};
 
   # Pin GCC/CLang versions
-  stdenv = if pkgs.stdenv.isLinux then pkgs.gcc13Stdenv else pkgs.clang16Stdenv;
+  stdenv = if pkgs.stdenv.isLinux then pkgs.gcc13Stdenv else pkgs.clang18Stdenv;
 
 in stdenv.mkDerivation rec {
   pname = "storage";


### PR DESCRIPTION
Pins nixpkgs to a commit from the 25.11 release — the same commit logos-delivery uses.

Needed for the status-go upgrade to Go 1.26 (status-im/status-go#7651): its flake moves to nixpkgs 25.11, and this lets `logos-storage-nim` follow the parent nixpkgs again instead of carrying its own.

Fallout from 24.11 → 25.11: `nodejs_18` and `clang16Stdenv` no longer exist, replaced with `nodejs_20` and `clang18Stdenv`.