### PR TITLE
[NOT TO MERGE] chore: bump nixpkgs to 25.11 (for current status-go pin)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,20 @@
   "nodes": {
     "circom-compat": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736521871,
-        "narHash": "sha256-d34XNLg9NGPEOARHW+BIOAWalkHdEUAwsv3mpLZQxds=",
+        "lastModified": 1779967405,
+        "narHash": "sha256-UP0D5UinZj36LoMv07BhjZuZxYABNDHz975fUXGxjKU=",
         "owner": "logos-storage",
         "repo": "circom-compat-ffi",
-        "rev": "8cd4ed44fdafe59d4ec1184420639cae4c4dbab9",
+        "rev": "3cca4e91054a4d2bb5335feb19138362ce0fe417",
         "type": "github"
       },
       "original": {
         "owner": "logos-storage",
         "repo": "circom-compat-ffi",
+        "rev": "3cca4e91054a4d2bb5335feb19138362ce0fe417",
         "type": "github"
       }
     },
@@ -36,10 +35,26 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "circom-compat": "circom-compat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,10 @@
   description = "Logos Storage build flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    circom-compat = {
-      url = "github:logos-storage/circom-compat-ffi";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # A commit from nixpkgs 25.11 release: https://github.com/NixOS/nixpkgs/tree/release-25.11
+    nixpkgs.url = "github:NixOS/nixpkgs/535f3e6942cb1cead3929c604320d3db54b542b9";
+    # No follows: its fetchurl overlay doesn't evaluate against nixpkgs 25.11.
+    circom-compat.url = "github:logos-storage/circom-compat-ffi/3cca4e91054a4d2bb5335feb19138362ce0fe417";
   };
 
   outputs = { self, nixpkgs, circom-compat}:
@@ -46,7 +45,7 @@
             circom-compat.packages.${system}.default
           ];
           # Not using buildInputs to override fakeGit and fakeCargo.
-          nativeBuildInputs = with pkgs; [ git cargo nodejs_18 ];
+          nativeBuildInputs = with pkgs; [ git cargo nodejs_20 ];
         };
       });
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,7 +28,7 @@ let
   tools = callPackage ./tools.nix {};
 
   # Pin GCC/CLang versions
-  stdenv = if pkgs.stdenv.isLinux then pkgs.gcc13Stdenv else pkgs.clang16Stdenv;
+  stdenv = if pkgs.stdenv.isLinux then pkgs.gcc13Stdenv else pkgs.clang18Stdenv;
 
 in stdenv.mkDerivation rec {
   pname = "storage";


### PR DESCRIPTION
Same nixpkgs 25.11 bump as #1491, but branched from `3c09f008` — the revision status-go currently pins — so the libstorage API is unchanged.

Needed by the status-go Go 1.26 upgrade (status-im/status-go#7651): lets its flake keep `follows` on nixpkgs 25.11 without taking the new libstorage API from master (that upgrade, with logos-storage-go-bindings v0.3.x, comes separately).

Not meant to merge as-is — reference for the temporary status-go pin; superseded by #1491 once the API upgrade lands there.

Fallout from 24.11 → 25.11: `nodejs_18` → `nodejs_20`, `clang16Stdenv` → `clang18Stdenv`, and `circom-compat` no longer follows nixpkgs (its fetchurl overlay doesn't evaluate on 25.11).