### PR TITLE
fix: crash when config is invalid

### DIFF
--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -113,7 +113,8 @@ proc createStorage(
       ,
     )
   except ConfigurationError as e:
-    return err("Failed to create Storage: unable to load configuration: " & e.msg)
+    # We cannot use e.msg because it is not populated by config-utils
+    return err("Failed to create Storage: unable to load configuration.")
 
   let logFile = conf.setupLogging()
 

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -104,6 +104,7 @@ proc createStorage(
       version = storageFullVersion,
       envVarsPrefix = "storage",
       cmdLine = @[],
+      quitOnFailure = false,
       secondarySources = proc(
           config: StorageConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =

--- a/tests/integration/storageconfig.nim
+++ b/tests/integration/storageconfig.nim
@@ -61,9 +61,6 @@ proc buildConfig(
     return StorageConf.load(cmdLine = config.cliArgs, quitOnFailure = false)
   except ConfigurationError as e:
     raiseStorageConfigError msg & e.msg.postFix
-  except Exception as e:
-    ## TODO: remove once proper exception handling added to nim-confutils
-    raiseStorageConfigError msg & e.msg.postFix
 
 proc addCliOption*(
     config: var StorageConfig, group = StartUpCmd.noCmd, cliOption: CliOption

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -20,7 +20,9 @@ asyncchecksuite "Libstorage - config":
     let res = await request.process(addr server)
 
     check res.isErr
-    check "unable to load configuration" in res.error
+
+    if res.isErr:
+      check "unable to load configuration" in res.error
 
   test "rejects an unknown option":
     let request =
@@ -28,7 +30,9 @@ asyncchecksuite "Libstorage - config":
     let res = await request.process(addr server)
 
     check res.isErr
-    check "unable to load configuration" in res.error
+
+    if res.isErr:
+      check "unable to load configuration" in res.error
 
   test "accepts a valid config":
     let dataDir = getTempDir() / "libstorage-config" / $getMonoTime()

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -1,3 +1,4 @@
+import std/json
 import std/monotimes
 import std/os
 import std/strutils
@@ -40,7 +41,8 @@ asyncchecksuite "Libstorage - config":
     defer:
       removeDir(dataDir)
 
-    let config = """{"data-dir": "$1"}""" % [dataDir]
+    # %* escapes the path so that it can be used in JSON.
+    let config = $ %*{"data-dir": dataDir}
     let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
     let res = await request.process(addr server)
 

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -36,7 +36,7 @@ asyncchecksuite "Libstorage - config":
     defer:
       removeDir(dataDir)
 
-    let config = """{"data-dir": "$1", "log-level": "DEBUG"}""" % [dataDir]
+    let config = """{"data-dir": "$1"}""" % [dataDir]
     let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
     let res = await request.process(addr server)
 

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -1,3 +1,5 @@
+import std/monotimes
+import std/os
 import std/strutils
 
 import pkg/chronos
@@ -29,8 +31,16 @@ asyncchecksuite "Libstorage - config":
     check "unable to load configuration" in res.error
 
   test "accepts a valid config":
-    let request =
-      NodeLifecycleRequest.createShared(CREATE_NODE, """{"log-level": "DEBUG"}""")
+    let dataDir = getTempDir() / "libstorage-config" / $getMonoTime()
+
+    defer:
+      removeDir(dataDir)
+
+    let config = """{"data-dir": "$1", "log-level": "DEBUG"}""" % [dataDir]
+    let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
     let res = await request.process(addr server)
 
     check res.isOk
+
+    let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
+    check (await closeRequest.process(addr server)).isOk

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -1,0 +1,36 @@
+import std/strutils
+
+import pkg/chronos
+import pkg/results
+
+import ../asynctest
+import ../checktest
+import ../../library/storage_thread_requests/requests/node_lifecycle_request
+
+from ../../storage/storage import StorageServer
+
+asyncchecksuite "Libstorage - config":
+  var server: StorageServer
+
+  test "rejects malformed JSON":
+    let request =
+      NodeLifecycleRequest.createShared(CREATE_NODE, """{"log-level": "debug"""")
+    let res = await request.process(addr server)
+
+    check res.isErr
+    check "unable to load configuration" in res.error
+
+  test "rejects an unknown option":
+    let request =
+      NodeLifecycleRequest.createShared(CREATE_NODE, """{"unknown": "debug"}""")
+    let res = await request.process(addr server)
+
+    check res.isErr
+    check "unable to load configuration" in res.error
+
+  test "accepts a valid config":
+    let request =
+      NodeLifecycleRequest.createShared(CREATE_NODE, """{"log-level": "DEBUG"}""")
+    let res = await request.process(addr server)
+
+    check res.isOk

--- a/tests/testLibstorage.nim
+++ b/tests/testLibstorage.nim
@@ -1,4 +1,5 @@
 # Tests the Nim side of libstorage.
+import ./libstorage/config
 import ./libstorage/logosmetrics
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
This PR ensures that `libstorage` doesn't crash when we provide an invalid config.

The `catch Exception` was removed from `tests/integration/storageconfig.nim` because `load` seems to raise only `ConfigurationError`.

`quitOnFailure` is an option coming from `nim-confutils` : 

```nim
  template fail(args: varargs[untyped]): untyped =
    if quitOnFailure:
      errorOutput args
      errorOutput "\p"
      suggestCallingHelp()
    else:
      # TODO: populate this string
      raise newException(ConfigurationError, "")
```