### PR TITLE
fix: potential double free

### DIFF
--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -104,21 +104,26 @@ proc sendRequestToStorageThread*(
   # Notify the Logos Storage thread that a request is available
   let fireSyncRes = ctx.reqSignal.fireSync()
   if fireSyncRes.isErr():
+    # We do not free the request here: it is already published in the channel,
+    # and freeing it would leave a dangling pointer if the code later retries
+    # to wake up the thread.
     return err(
       "Failed to send request to the Logos Storage thread: unable to fireSync: " &
         $fireSyncRes.error
     )
 
   if fireSyncRes.get() == false:
+    # Same as above: we do not free the request here.
     return
       err("Failed to send request to the Logos Storage thread: fireSync timed out.")
 
-  # Wait until the Logos Storage thread properly received the request
+  # From here the request is owned by the Logos Storage thread, which frees it
+  # in handleRes: returning an error would fire the callback a second time,
+  # on a context the client has already freed.
   let res = ctx.reqReceivedSignal.waitSync(timeout)
   if res.isErr():
-    return err(
-      "Failed to send request to the Logos Storage thread: unable to receive reqReceivedSignal signal."
-    )
+    error "Failed to get the signal from Logos Storage thread.", error = res.error
+    return ok()
 
   ## Notice that in case of "ok", the deallocShared(req) is performed by the Logos Storage thread in the
   ## process proc. See the 'storage_thread_request.nim' module for more details.

--- a/library/storage_context.nim
+++ b/library/storage_context.nim
@@ -117,9 +117,8 @@ proc sendRequestToStorageThread*(
     return
       err("Failed to send request to the Logos Storage thread: fireSync timed out.")
 
-  # From here the request is owned by the Logos Storage thread, which frees it
-  # in handleRes: returning an error would fire the callback a second time,
-  # on a context the client has already freed.
+  # From here the Logos Storage thread will call the callback: returning an
+  # error would fire it a second time, on a context the client has already freed.
   let res = ctx.reqReceivedSignal.waitSync(timeout)
   if res.isErr():
     error "Failed to get the signal from Logos Storage thread.", error = res.error


### PR DESCRIPTION
This PR fixes a potential issue reported by the audit [119](https://github.com/logos-co/audit-reports/issues/119).

After sending the request to the thread, the `waitSync` might fail and return an error. This error fires an error callback call to the module, which frees the callback context. And because the request is already sent to the thread, the callback will be called twice, which is a memory issue.

Note that `waitSync` is called with `InfiniteDuration`, so it cannot fail for a timeout reason: while this behaviour has to be fixed, the scenario described in the report is not reachable in the current codebase.

Other part of the audit fix [here](https://github.com/logos-co/logos-storage-module/pull/75).