### PR TITLE
fix(rest): prevent IndexDefect on short/unquoted Content-Disposition filenames and support RFC-compliant unquoted headers

### DIFF
--- a/storage/rest/api.nim
+++ b/storage/rest/api.nim
@@ -12,6 +12,8 @@
 import std/sequtils
 import std/mimetypes
 import std/os
+import std/strutils
+import std/uri
 
 import pkg/questionable
 import pkg/questionable/results
@@ -169,6 +171,27 @@ proc setCorsHeaders(resp: HttpResponseRef, httpMethod: string, origin: string) =
   resp.setHeader("Access-Control-Max-Age", "86400")
 
 proc getFilenameFromContentDisposition*(contentDisposition: string): ?string =
+  # RFC 6266 / RFC 5987: filename* parameter takes precedence over filename
+  let idxExt = contentDisposition.find("filename*=")
+  if idxExt != -1:
+    var val = contentDisposition[idxExt + "filename*=".len .. ^1].strip()
+    if val.len > 0:
+      let semiIdx = val.find(";")
+      if semiIdx != -1:
+        val = val[0 .. semiIdx - 1].strip()
+      if val.startsWith("\"") and val.endsWith("\"") and val.len >= 2:
+        val = val[1 .. ^2].strip()
+      let quoteIdx = val.rfind("''")
+      if quoteIdx != -1 and quoteIdx + 2 < val.len:
+        val = val[quoteIdx + 2 .. ^1]
+      try:
+        val = decodeUrl(val)
+      except CatchableError:
+        discard
+      val = val.strip(chars = {'"'})
+      if val.len > 0:
+        return val.some
+
   let idx = contentDisposition.find("filename=")
   if idx == -1:
     return string.none
@@ -187,6 +210,7 @@ proc getFilenameFromContentDisposition*(contentDisposition: string): ?string =
     let semiIdx = val.find(";")
     if semiIdx != -1:
       val = val[0 .. semiIdx - 1].strip()
+    val = val.strip(chars = {'"'})
     if val.len > 0:
       return val.some
     else:

--- a/storage/rest/api.nim
+++ b/storage/rest/api.nim
@@ -168,17 +168,29 @@ proc setCorsHeaders(resp: HttpResponseRef, httpMethod: string, origin: string) =
   resp.setHeader("Access-Control-Allow-Methods", httpMethod & ", OPTIONS")
   resp.setHeader("Access-Control-Max-Age", "86400")
 
-proc getFilenameFromContentDisposition(contentDisposition: string): ?string =
-  if not ("filename=" in contentDisposition):
+proc getFilenameFromContentDisposition*(contentDisposition: string): ?string =
+  let idx = contentDisposition.find("filename=")
+  if idx == -1:
     return string.none
 
-  let parts = contentDisposition.split("filename=\"")
-
-  if parts.len < 2:
+  var val = contentDisposition[idx + "filename=".len .. ^1].strip()
+  if val.len == 0:
     return string.none
 
-  let filename = parts[1].strip()
-  return filename[0 ..^ 2].some
+  if val.startsWith("\""):
+    let endQuote = val.find("\"", 1)
+    if endQuote > 1:
+      return val[1 .. endQuote - 1].some
+    else:
+      return string.none
+  else:
+    let semiIdx = val.find(";")
+    if semiIdx != -1:
+      val = val[0 .. semiIdx - 1].strip()
+    if val.len > 0:
+      return val.some
+    else:
+      return string.none
 
 proc initDataApi(node: StorageNodeRef, repoStore: RepoStore, router: var RestRouter) =
   let allowedOrigin = router.allowedOrigin # prevents capture inside of api defintion

--- a/tests/storage/rest/testcontentdisposition.nim
+++ b/tests/storage/rest/testcontentdisposition.nim
@@ -16,6 +16,21 @@ suite "getFilenameFromContentDisposition":
   test "parse unquoted filename with parameters":
     check getFilenameFromContentDisposition("attachment; filename=data.csv; size=500") == "data.csv".some
 
+  test "parse RFC 5987 encoded filename*":
+    check getFilenameFromContentDisposition("attachment; filename*=UTF-8''file%20name.jpg") == "file name.jpg".some
+
+  test "parse form-data syntax with filename":
+    check getFilenameFromContentDisposition("form-data; name=\"fieldName\"; filename=\"filename.jpg\"") == "filename.jpg".some
+
+  test "handle form-data syntax without filename":
+    check getFilenameFromContentDisposition("form-data; name=\"fieldName\"").isNone
+
+  test "handle inline disposition":
+    check getFilenameFromContentDisposition("inline").isNone
+
+  test "handle unopened trailing quote":
+    check getFilenameFromContentDisposition("attachment; filename=unopened\"") == "unopened".some
+
   test "handle empty quoted filename safely":
     check getFilenameFromContentDisposition("attachment; filename=\"\"").isNone
 

--- a/tests/storage/rest/testcontentdisposition.nim
+++ b/tests/storage/rest/testcontentdisposition.nim
@@ -1,0 +1,27 @@
+import pkg/unittest2
+import pkg/questionable
+
+import pkg/storage/rest/api
+
+suite "getFilenameFromContentDisposition":
+  test "parse quoted filename":
+    check getFilenameFromContentDisposition("attachment; filename=\"document.pdf\"") == "document.pdf".some
+
+  test "parse quoted filename with parameters":
+    check getFilenameFromContentDisposition("attachment; filename=\"report.txt\"; size=1234") == "report.txt".some
+
+  test "parse unquoted filename":
+    check getFilenameFromContentDisposition("attachment; filename=plain.txt") == "plain.txt".some
+
+  test "parse unquoted filename with parameters":
+    check getFilenameFromContentDisposition("attachment; filename=data.csv; size=500") == "data.csv".some
+
+  test "handle empty quoted filename safely":
+    check getFilenameFromContentDisposition("attachment; filename=\"\"").isNone
+
+  test "handle malformed unclosed quote":
+    check getFilenameFromContentDisposition("attachment; filename=\"unclosed").isNone
+
+  test "handle missing filename":
+    check getFilenameFromContentDisposition("attachment").isNone
+    check getFilenameFromContentDisposition("").isNone


### PR DESCRIPTION
Updated getFilenameFromContentDisposition in storage/rest/api.nim to safely parse filenames from HTTP Content-Disposition headers. Previously, filename[0 ..^ 2] on empty/short or unclosed quoted string parameters caused IndexDefect range panics. The updated logic safely matches quotes and semicolons and supports unquoted headers. Added unit test coverage.