### PR TITLE
fix: replace peerInfo.addrs with the extip when using nat:extip

### DIFF
--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -91,6 +91,29 @@ proc start*(s: StorageServer) {.async.} =
 
   await s.storageNode.switch.start()
 
+  var realPort = Port(0)
+
+  for listenAddr in s.storageNode.switch.peerInfo.listenAddrs:
+    let maybePort = getTcpPort(listenAddr)
+    if maybePort.isSome:
+      realPort = maybePort.get
+      break
+
+  if realPort == Port(0):
+    raise newException(StorageError, "Failed to determine the real TCP port")
+
+  if s.config.nat.hasExtIp:
+    # extip means that we assume the IP is reachable.
+    let extIpAddr = getMultiAddrWithIpAndTcpPort(s.config.nat.extIp, realPort)
+
+    # Feed switch.peerInfo.addrs with extIp value only.
+    # For example, we want to make sure that relay servers will
+    # contain only the extIp, no private addresses.
+    let peerInfo = s.storageNode.switch.peerInfo
+    peerInfo.announcedAddrs = @[extIpAddr]
+    # We force the update to take in consideration the announcedAddrs
+    await peerInfo.update()
+
   # Activate SO_REUSEPORT for hole punching in tcptransport.nim.
   # Without that, hole punching would use an ephemeral port assigned by the OS.
   # NotReachable has nothing to do with AutoNAT Reachability
@@ -154,17 +177,6 @@ proc start*(s: StorageServer) {.async.} =
   if s.natMapper.isSome:
     s.natMapper.get.start()
 
-  var realPort = Port(0)
-
-  for listenAddr in s.storageNode.switch.peerInfo.listenAddrs:
-    let maybePort = getTcpPort(listenAddr)
-    if maybePort.isSome:
-      realPort = maybePort.get
-      break
-
-  if realPort == Port(0):
-    raise newException(StorageError, "Failed to determine the real TCP port")
-
   # When listenPort is 0 the OS assigns a random port. For UDP, the port
   # doesn't change so there is no need to update it.
   if s.natMapper.isSome and s.config.listenPort == Port(0):
@@ -177,14 +189,10 @@ proc start*(s: StorageServer) {.async.} =
     # extip means that we assume the IP is reachable.
     let extIpAddr = getMultiAddrWithIpAndTcpPort(s.config.nat.extIp, realPort)
 
-    # Feed switch.peerInfo.addrs with extIp value only.
-    # For example, we want to make sure that relay servers will
-    # contain only the extIp, no private addresses.
-    let peerInfo = s.storageNode.switch.peerInfo
-    peerInfo.announcedAddrs = @[extIpAddr]
-    # We force the update to take in consideration the announcedAddrs
-    await peerInfo.update()
-
+    # The addresses are announced during the start process
+    # only with extIp because they should be Reachable.
+    # For other nodes, wait for AutoNat to announce addresses and update SPR.
+    # Announced here and not above because Mix needs discovery.mixProto to be set.
     s.storageNode.discovery.announceDirectAddrs(
       @[extIpAddr], udpPort = s.config.discoveryPort
     )

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -109,7 +109,7 @@ proc start*(s: StorageServer) {.async.} =
         )
       # We define a placeholder here.
       # For nat:extip, the address will be updated when calling `announceDirectAddrs` below.
-      # For nat:any, the node waits for AutoNAT to provide a reachable address or a relay address.
+      # For nat:auto, the node waits for AutoNAT to provide a reachable address or a relay address.
       # The Mix lookup will not be performed while the mixAddr value is mixUnsetMultiAddr().
       mixAddr = mixUnsetMultiAddr()
       mixNodeInfo = buildMixNodeInfo(
@@ -154,32 +154,39 @@ proc start*(s: StorageServer) {.async.} =
   if s.natMapper.isSome:
     s.natMapper.get.start()
 
+  var realPort = Port(0)
+
+  for listenAddr in s.storageNode.switch.peerInfo.listenAddrs:
+    let maybePort = getTcpPort(listenAddr)
+    if maybePort.isSome:
+      realPort = maybePort.get
+      break
+
+  if realPort == Port(0):
+    raise newException(StorageError, "Failed to determine the real TCP port")
+
   # When listenPort is 0 the OS assigns a random port. For UDP, the port
   # doesn't change so there is no need to update it.
   if s.natMapper.isSome and s.config.listenPort == Port(0):
-    for listenAddr in s.storageNode.switch.peerInfo.listenAddrs:
-      let maybePort = getTcpPort(listenAddr)
-      if maybePort.isSome:
-        s.natMapper.get.tcpPort = maybePort.get
-        break
+    s.natMapper.get.tcpPort = realPort
 
   # The addresses are announced during the start process
   # only with extIp because they should be Reachable.
   # For other nodes, wait for AutoNat to announce addresses and update SPR.
   if s.config.nat.hasExtIp:
-    if s.storageNode.switch.peerInfo.addrs.len == 0:
-      raise
-        newException(StorageError, "extip is set but switch has no listen addresses")
-
     # extip means that we assume the IP is reachable.
-    # So we just take the first peer addr and remap it with extip to keep the port only.
-    let providerAddrs = @[
-      s.storageNode.switch.peerInfo.addrs[0].remapAddr(
-        ip = some(s.config.nat.extIp), port = none(Port)
-      )
-    ]
+    let extIpAddr = getMultiAddrWithIpAndTcpPort(s.config.nat.extIp, realPort)
+
+    # Feed switch.peerInfo.addrs with extIp value only.
+    # For example, we want to make sure that relay servers will
+    # contain only the extIp, no private addresses.
+    let peerInfo = s.storageNode.switch.peerInfo
+    peerInfo.announcedAddrs = @[extIpAddr]
+    # We force the update to take in consideration the announcedAddrs
+    await peerInfo.update()
+
     s.storageNode.discovery.announceDirectAddrs(
-      providerAddrs, udpPort = s.config.discoveryPort
+      @[extIpAddr], udpPort = s.config.discoveryPort
     )
   else:
     # Other nodes wait for AutoNAT to announce addresses and update SPR.

--- a/tests/integration/1_minute/testextipaddresses.nim
+++ b/tests/integration/1_minute/testextipaddresses.nim
@@ -1,0 +1,18 @@
+import std/json
+import std/sequtils
+
+import pkg/questionable/results
+
+import ../multinodes
+
+multinodesuite "peer addresses":
+  test "should not set peer address to listen address when extip is specified",
+    NodeConfigs(clients: StorageConfigs
+        .init(nodes = 2)
+        .withExtIp(1, ip = "7.7.7.2")
+        .withListenPort(1, 40401)
+        .debug(1, true).some
+    ):
+
+    let info = (await clients()[1].client.info()).get
+    check info["addrs"] == %*["/ip4/7.7.7.2/tcp/40401"]

--- a/tests/integration/1_minute/testextipaddresses.nim
+++ b/tests/integration/1_minute/testextipaddresses.nim
@@ -6,12 +6,12 @@ import ../multinodes
 
 multinodesuite "peer addresses":
   test "should not set peer address to listen address when extip is specified",
-    NodeConfigs(clients: StorageConfigs
+    NodeConfigs(
+      clients: StorageConfigs
         .init(nodes = 2)
         .withExtIp(1, ip = "7.7.7.2")
         .withListenPort(1, 40401)
         .debug(1, true).some
     ):
-
     let info = (await clients()[1].client.info()).get
     check info["addrs"] == %*["/ip4/7.7.7.2/tcp/40401"]

--- a/tests/integration/1_minute/testextipaddresses.nim
+++ b/tests/integration/1_minute/testextipaddresses.nim
@@ -1,5 +1,4 @@
 import std/json
-import std/sequtils
 
 import pkg/questionable/results
 

--- a/tests/integration/nat/relay-download/README.md
+++ b/tests/integration/nat/relay-download/README.md
@@ -39,5 +39,7 @@ B is `NotReachable` and announces its circuit address, while C is `Reachable`.
 B uploads a file, then C fetches it over the network through the relay and gets
 the same content back.
 
+A second check ensures that the relay server does not expose private addresses.
+
 Per-run container logs (router, bootstrap, client, node) are written before teardown to
 `tests/integration/logs/<timestamp>__NAT_relay_download/<test>/<service>.log`.

--- a/tests/integration/nat/relay-download/compose.yml
+++ b/tests/integration/nat/relay-download/compose.yml
@@ -54,6 +54,8 @@ services:
     networks:
       wan:
         ipv4_address: *bootstrap_ip
+    ports:
+      - "127.0.0.1:18092:8080"
     volumes:
       - ../node-entrypoint.sh:/scripts/node-entrypoint.sh:ro,z
     entrypoint: ["bash", "/scripts/node-entrypoint.sh"]

--- a/tests/integration/nat/relay-download/testrelaydownload.nim
+++ b/tests/integration/nat/relay-download/testrelaydownload.nim
@@ -16,28 +16,34 @@ proc announcesCircuitAddr(info: JsonNode): bool =
 asyncchecksuite "NAT relay download":
   let
     composeFile = currentSourcePath.parentDir / "compose.yml"
+    bootstrapApiUrl = "http://127.0.0.1:18092/api/storage/v1"
     nodeApiUrl = "http://127.0.0.1:18086/api/storage/v1"
     clientApiUrl = "http://127.0.0.1:18087/api/storage/v1"
     suiteName = "NAT relay download"
-    testName = "a NAT'd node behind a relay can be downloaded from"
     services = ["router", "bootstrap", "client", "node"]
     startTime = now().format("yyyy-MM-dd'_'HH:mm:ss")
   var
+    bootstrapClient: StorageClient
     nodeClient: StorageClient
     clientC: StorageClient
+    currentTest: string
 
   setup:
     compose(composeFile, "up -d")
+    bootstrapClient = StorageClient.new(bootstrapApiUrl)
     nodeClient = StorageClient.new(nodeApiUrl)
     clientC = StorageClient.new(clientApiUrl)
 
   teardown:
+    await bootstrapClient.close()
     await nodeClient.close()
     await clientC.close()
-    saveContainerLogs(composeFile, suiteName, testName, startTime, services)
+    saveContainerLogs(composeFile, suiteName, currentTest, startTime, services)
     compose(composeFile, "down -v")
 
-  test testName:
+  test "a NAT'd node behind a relay can be downloaded from":
+    currentTest = "a NAT'd node behind a relay can be downloaded from"
+
     # B is NotReachable and falls back to the relay, announcing its circuit address
     check eventuallyInfo(
       nodeClient,
@@ -60,3 +66,16 @@ asyncchecksuite "NAT relay download":
     let res = await clientC.download(cid)
     check res.isOk
     check res.get == content
+
+  test "the relay server exposes no private address":
+    currentTest = "the relay server exposes no private address"
+
+    # Ensure the relay server has at least one address (it should have a public one)
+    check eventuallyInfo(bootstrapClient, info{"addrs"}.getElems.len > 0)
+
+    let info = (await bootstrapClient.info()).get
+
+    # Ensure that the switch.peersInfo.addrs contains
+    # only public addresses (no private addresses).
+    check info{"addrs"}.getElems.mapIt(it.getStr) ==
+      @["/ip4/" & bootstrapIp & "/tcp/8070"]

--- a/tests/integration/storageconfig.nim
+++ b/tests/integration/storageconfig.nim
@@ -247,6 +247,14 @@ proc withMixEnabled*(
     config.addCliOption("--mix-enabled")
   return startConfig
 
+proc withListenPort*(
+    self: StorageConfigs, idx: int, port: int
+): StorageConfigs {.raises: [StorageConfigError].} =
+  self.checkBounds idx
+  var startConfig = self
+  startConfig.configs[idx].addCliOption("--listen-port", $port)
+  return startConfig
+
 # For testing, a node with extip (not behind nat) with autonat server
 # enabled is a bootstrap node
 proc isBootstrapNode*(config: StorageConfig): bool {.raises: [].} =


### PR DESCRIPTION
## Problem

Relay servers use `switch.peerInfo.addrs` (see [here](https://github.com/vacp2p/nim-libp2p/blob/0253e455f4da4230ac3101105bcc51b21c037121/libp2p/protocols/connectivity/relay/relay.nim#L87)) to create a reservation.
This is problematic when `listen-ip` is `0.0.0.0` and the public IP is not on any network interface.
Result: the relay server creates a reservation with private addresses, which will not be announced because of our public address filter.

## Solution

This PR fixes the issue by setting `peerInfo.announcedAddrs` when `extip` is used. [libp2p uses these addresses when the peerInfo is updated](https://github.com/vacp2p/nim-libp2p/blob/0253e455f4da4230ac3101105bcc51b21c037121/libp2p/peerinfo.nim#L90-L91).
Result: `switch.peerInfo.addrs` contains the public IP only, and the reservation is announced.

## Note

We could use `withAnnouncedAddresses` when creating the switch but that would require to set the `listen-port` with `nat:extip`.