### PR TITLE
feat: expose api enabled in the config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,6 @@ else
 endif
 export CXXFLAGS
 
-LIBSTORAGE_PARAMS :=
-# By default, libstorage disables the restapi. To build libstorage with the rest
-# api enabled for remote debugging, use `make DEBUG=1 libstorage`
-ifeq ($(DEBUG),1)
-	LIBSTORAGE_PARAMS := $(LIBSTORAGE_PARAMS) -d:LibstorageDisableRestApi=0
-else ifeq ($(DEBUG),0)
-	LIBSTORAGE_PARAMS := $(LIBSTORAGE_PARAMS) -d:LibstorageDisableRestApi=1
-endif
-
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 
@@ -325,16 +316,16 @@ libstorage:
 
 ifeq ($(STATIC), 1)
 		echo -e $(BUILD_MSG) "build/$@.a" && \
-		$(ENV_SCRIPT) nim libstorageStatic $(NIM_PARAMS) $(LIBSTORAGE_PARAMS) storage.nims
+		$(ENV_SCRIPT) nim libstorageStatic $(NIM_PARAMS) storage.nims
 else ifeq ($(detected_OS),Windows)
 		echo -e $(BUILD_MSG) "build/$@.dll" && \
-		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) $(LIBSTORAGE_PARAMS) storage.nims
+		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) storage.nims
 else ifeq ($(detected_OS),macOS)
 		echo -e $(BUILD_MSG) "build/$@.dylib" && \
-		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) $(LIBSTORAGE_PARAMS) storage.nims
+		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) storage.nims
 else
 		echo -e $(BUILD_MSG) "build/$@.so" && \
-		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) $(LIBSTORAGE_PARAMS) storage.nims
+		$(ENV_SCRIPT) nim libstorageDynamic $(NIM_PARAMS) storage.nims
 endif
 endif # "variables.mk" was not includedMa
 ################

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -27,7 +27,7 @@ from ../../../storage/storage import StorageServer, new, start, stop, close
 logScope:
   topics = "libstorage libstoragelifecycle"
 
-const LibstorageDisableRestApi* {.booldefine.} = true
+const LibstorageDefaultConfig = """{"api-enabled": false}"""
 
 type NodeLifecycleMsgType* = enum
   CREATE_NODE
@@ -110,7 +110,7 @@ proc createStorage(
       ) {.gcsafe, raises: [ConfigurationError].} =
         if configJson.len > 0:
           sources.addConfigFileContent(Json, $(configJson))
-      ,
+        sources.addConfigFileContent(Json, LibstorageDefaultConfig),
     )
   except ConfigurationError as e:
     # We cannot use e.msg because it is not populated by config-utils
@@ -150,12 +150,6 @@ proc createStorage(
   if privateKey.isErr:
     return err("Failed to create Storage: unable to get the private key.")
   let pk = privateKey.get()
-
-  when LibstorageDisableRestApi:
-    conf.apiBindAddress = string.none
-    debug "Rest API is disabled!"
-  else:
-    debug "Rest API is enabled!"
 
   let server =
     try:

--- a/library/storage_thread_requests/requests/node_lifecycle_request.nim
+++ b/library/storage_thread_requests/requests/node_lifecycle_request.nim
@@ -27,8 +27,6 @@ from ../../../storage/storage import StorageServer, new, start, stop, close
 logScope:
   topics = "libstorage libstoragelifecycle"
 
-const LibstorageDefaultConfig = """{"api-enabled": false}"""
-
 type NodeLifecycleMsgType* = enum
   CREATE_NODE
   START_NODE
@@ -110,7 +108,7 @@ proc createStorage(
       ) {.gcsafe, raises: [ConfigurationError].} =
         if configJson.len > 0:
           sources.addConfigFileContent(Json, $(configJson))
-        sources.addConfigFileContent(Json, LibstorageDefaultConfig),
+      ,
     )
   except ConfigurationError as e:
     # We cannot use e.msg because it is not populated by config-utils

--- a/storage.nim
+++ b/storage.nim
@@ -38,7 +38,7 @@ when isMainModule:
   when defined(posix):
     import system/ansi_c
 
-  const StandaloneDefaultConfig = "api-enabled = true"
+  const StandaloneDefaultConfig = "api-bindaddr = \"" & DefaultApiBindAddress & "\""
 
   type StorageStatus {.pure.} = enum
     Stopped

--- a/storage.nim
+++ b/storage.nim
@@ -38,6 +38,8 @@ when isMainModule:
   when defined(posix):
     import system/ansi_c
 
+  const StandaloneDefaultConfig = "api-enabled = true"
+
   type StorageStatus {.pure.} = enum
     Stopped
     Stopping
@@ -51,7 +53,8 @@ when isMainModule:
     ) {.gcsafe, raises: [ConfigurationError].} =
       if configFile =? config.configFile:
         sources.addConfigFile(Toml, configFile)
-    ,
+      # Sources are read in order: the config file wins over these defaults
+      sources.addConfigFileContent(Toml, StandaloneDefaultConfig),
   )
 
   let logFile = config.setupLogging()

--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -257,7 +257,7 @@ type
     .}: string
 
     apiEnabled* {.
-      desc: "Enable the REST API", defaultValue: true, name: "api-enabled", hidden
+      desc: "Enable the REST API", defaultValue: false, name: "api-enabled", hidden
     .}: bool
 
     apiBindAddress* {.

--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -256,6 +256,10 @@ type
       name: "agent-string"
     .}: string
 
+    apiEnabled* {.
+      desc: "Enable the REST API", defaultValue: true, name: "api-enabled", hidden
+    .}: bool
+
     apiBindAddress* {.
       desc: "The REST API bind address",
       defaultValue: "127.0.0.1".some,

--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -78,6 +78,7 @@ const
   storage_enable_log_counter* {.booldefine.} = false
 
   DefaultThreadCount* = ThreadCount(0)
+  DefaultApiBindAddress* = "127.0.0.1"
 
 type
   StartUpCmd* {.pure.} = enum
@@ -256,13 +257,10 @@ type
       name: "agent-string"
     .}: string
 
-    apiEnabled* {.
-      desc: "Enable the REST API", defaultValue: false, name: "api-enabled", hidden
-    .}: bool
-
     apiBindAddress* {.
       desc: "The REST API bind address",
-      defaultValue: "127.0.0.1".some,
+      defaultValue: string.none,
+      defaultValueDesc: DefaultApiBindAddress,
       name: "api-bindaddr"
     .}: Option[string]
 

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -578,7 +578,7 @@ proc new*(
   # REST server
   var restServer: RestServerRef = nil
 
-  if config.apiEnabled and config.apiBindAddress.isSome:
+  if config.apiBindAddress.isSome:
     restServer = RestServerRef
       .new(
         storageNode.initRestApi(

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -578,7 +578,7 @@ proc new*(
   # REST server
   var restServer: RestServerRef = nil
 
-  if config.apiBindAddress.isSome:
+  if config.apiEnabled and config.apiBindAddress.isSome:
     restServer = RestServerRef
       .new(
         storageNode.initRestApi(

--- a/tests/integration/multinodes.nim
+++ b/tests/integration/multinodes.nim
@@ -122,6 +122,7 @@ template multinodesuite*(suiteName: string, body: untyped) =
         withLock(storagePortLock):
           apiPort = await nextFreePort(lastUsedStorageApiPort + nodeIdx)
           discPort = await nextFreePort(lastUsedStorageDiscPort + nodeIdx)
+          config.addCliOption("--api-bindaddr", DefaultApiBindAddress)
           config.addCliOption("--api-port", $apiPort)
           config.addCliOption("--disc-port", $discPort)
           lastUsedStorageApiPort = apiPort

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -1,5 +1,6 @@
 import std/json
 import std/monotimes
+import std/options
 import std/os
 import std/strutils
 
@@ -11,6 +12,7 @@ import ../checktest
 import ../../library/storage_thread_requests/requests/node_lifecycle_request
 
 from ../../storage/storage import StorageServer, config
+from ../../storage/conf import DefaultApiBindAddress
 
 asyncchecksuite "Libstorage - config":
   var server: StorageServer
@@ -61,7 +63,7 @@ asyncchecksuite "Libstorage - config":
     let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
     check (await request.process(addr server)).isOk
 
-    check server.config.apiEnabled == false
+    check server.config.apiBindAddress.isNone
 
     let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
     check (await closeRequest.process(addr server)).isOk
@@ -72,11 +74,11 @@ asyncchecksuite "Libstorage - config":
     defer:
       removeDir(dataDir)
 
-    let config = $ %*{"data-dir": dataDir, "api-enabled": true}
+    let config = $ %*{"data-dir": dataDir, "api-bindaddr": DefaultApiBindAddress}
     let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
     check (await request.process(addr server)).isOk
 
-    check server.config.apiEnabled == true
+    check server.config.apiBindAddress == DefaultApiBindAddress.some
 
     let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
     check (await closeRequest.process(addr server)).isOk

--- a/tests/libstorage/config.nim
+++ b/tests/libstorage/config.nim
@@ -10,7 +10,7 @@ import ../asynctest
 import ../checktest
 import ../../library/storage_thread_requests/requests/node_lifecycle_request
 
-from ../../storage/storage import StorageServer
+from ../../storage/storage import StorageServer, config
 
 asyncchecksuite "Libstorage - config":
   var server: StorageServer
@@ -47,6 +47,36 @@ asyncchecksuite "Libstorage - config":
     let res = await request.process(addr server)
 
     check res.isOk
+
+    let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
+    check (await closeRequest.process(addr server)).isOk
+
+  test "disables the REST API by default":
+    let dataDir = getTempDir() / "libstorage-config" / $getMonoTime()
+
+    defer:
+      removeDir(dataDir)
+
+    let config = $ %*{"data-dir": dataDir}
+    let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
+    check (await request.process(addr server)).isOk
+
+    check server.config.apiEnabled == false
+
+    let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
+    check (await closeRequest.process(addr server)).isOk
+
+  test "enables the REST API when the config asks for it":
+    let dataDir = getTempDir() / "libstorage-config" / $getMonoTime()
+
+    defer:
+      removeDir(dataDir)
+
+    let config = $ %*{"data-dir": dataDir, "api-enabled": true}
+    let request = NodeLifecycleRequest.createShared(CREATE_NODE, config.cstring)
+    check (await request.process(addr server)).isOk
+
+    check server.config.apiEnabled == true
 
     let closeRequest = NodeLifecycleRequest.createShared(CLOSE_NODE)
     check (await closeRequest.process(addr server)).isOk


### PR DESCRIPTION
This PR uses `ApiBindAddress` to detect if the HTTP API is enabled instead of relying on a configuration flag.