### PR TITLE
chore: bump nimble version

### DIFF
--- a/storage.nimble
+++ b/storage.nimble
@@ -1,4 +1,4 @@
-version = "0.1.0"
+version = "0.4.5"
 author = "Logos Storage Team"
 description = "p2p data durability engine"
 license = "MIT"

--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -261,7 +261,8 @@ type
       desc: "The REST API bind address",
       defaultValue: string.none,
       defaultValueDesc: DefaultApiBindAddress,
-      name: "api-bindaddr"
+      name: "api-bindaddr",
+      hidden
     .}: Option[string]
 
     apiPort* {.
@@ -269,7 +270,8 @@ type
       defaultValue: 8080.Port,
       defaultValueDesc: "8080",
       name: "api-port",
-      abbr: "p"
+      abbr: "p",
+      hidden
     .}: Port
 
     apiCorsAllowedOrigin* {.
@@ -278,7 +280,8 @@ type
         "'*' will allow all origins, '' will allow none.",
       defaultValue: string.none,
       defaultValueDesc: "Disallow all cross origin requests to download data",
-      name: "api-cors-origin"
+      name: "api-cors-origin",
+      hidden
     .}: Option[string]
 
     repoKind* {.


### PR DESCRIPTION
This PR prepares for release 0.4.5 by bumping nimble version and hide HTTP API config. 