### PR TITLE
feat: option for advertising content

### DIFF
--- a/storage/blockexchange/engine/advertiser.nim
+++ b/storage/blockexchange/engine/advertiser.nim
@@ -160,6 +160,7 @@ proc stop*(b: Advertiser) {.async: (raises: []).} =
   ##
 
   trace "Advertiser stop"
+
   if not b.advertiseContent:
     return
 

--- a/storage/blockexchange/engine/advertiser.nim
+++ b/storage/blockexchange/engine/advertiser.nim
@@ -37,6 +37,8 @@ type Advertiser* = ref object of RootObj
   localStore*: BlockStore # Local block store for this instance
   discovery*: Discovery # Discovery interface
 
+  advertiseContent: bool # Announce local content to the DHT
+
   advertiserRunning*: bool # Indicates if discovery is running
   concurrentAdvReqs: int # Concurrent advertise requests
 
@@ -128,6 +130,10 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
 
   trace "Advertiser start"
 
+  if not b.advertiseContent:
+    info "Content advertising is disabled, this node will not become a provider"
+    return
+
   # The advertiser is expected to be started only once.
   if b.advertiserRunning:
     raiseAssert "Advertiser can only be started once — this should not happen"
@@ -154,6 +160,9 @@ proc stop*(b: Advertiser) {.async: (raises: []).} =
   ##
 
   trace "Advertiser stop"
+  if not b.advertiseContent:
+    return
+
   if not b.advertiserRunning:
     warn "Stopping advertiser without starting it"
     return
@@ -172,6 +181,7 @@ proc new*(
     peerInfo: PeerInfo,
     concurrentAdvReqs = DefaultConcurrentAdvertRequests,
     advertiseLocalStoreLoopSleep = DefaultAdvertiseLoopSleep,
+    advertiseContent = true,
 ): Advertiser =
   ## Create a advertiser instance
   ##
@@ -179,6 +189,7 @@ proc new*(
     localStore: localStore,
     discovery: discovery,
     peerInfo: peerInfo,
+    advertiseContent: advertiseContent,
     concurrentAdvReqs: concurrentAdvReqs,
     advertiseQueue: newAsyncQueue[Cid](concurrentAdvReqs),
     trackedFutures: TrackedFutures.new(),

--- a/storage/blockexchange/engine/advertiser.nim
+++ b/storage/blockexchange/engine/advertiser.nim
@@ -38,7 +38,6 @@ type Advertiser* = ref object of RootObj
   discovery*: Discovery # Discovery interface
 
   advertiseContent: bool # Announce local or downloaded content
-
   advertiserRunning*: bool # Indicates if discovery is running
   concurrentAdvReqs: int # Concurrent advertise requests
 

--- a/storage/blockexchange/engine/advertiser.nim
+++ b/storage/blockexchange/engine/advertiser.nim
@@ -37,7 +37,7 @@ type Advertiser* = ref object of RootObj
   localStore*: BlockStore # Local block store for this instance
   discovery*: Discovery # Discovery interface
 
-  advertiseContent: bool # Announce local content
+  advertiseContent: bool # Announce local or downloaded content
 
   advertiserRunning*: bool # Indicates if discovery is running
   concurrentAdvReqs: int # Concurrent advertise requests

--- a/storage/blockexchange/engine/advertiser.nim
+++ b/storage/blockexchange/engine/advertiser.nim
@@ -37,7 +37,7 @@ type Advertiser* = ref object of RootObj
   localStore*: BlockStore # Local block store for this instance
   discovery*: Discovery # Discovery interface
 
-  advertiseContent: bool # Announce local content to the DHT
+  advertiseContent: bool # Announce local content
 
   advertiserRunning*: bool # Indicates if discovery is running
   concurrentAdvReqs: int # Concurrent advertise requests

--- a/storage/conf.nim
+++ b/storage/conf.nim
@@ -324,6 +324,14 @@ type
       name: "block-retries"
     .}: int
 
+    advertiseContent* {.
+      desc:
+        "Announce the content to the DHT and become a provider for this content, " &
+        "disable with --advertise-content=false",
+      defaultValue: true,
+      name: "advertise-content"
+    .}: bool
+
     discoveryTableIpLimit* {.
       desc: "Maximum number of nodes with the same IP in the discovery routing table",
       defaultValue: 10'u,

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -468,7 +468,12 @@ proc new*(
 
     peerStore = PeerContextStore.new()
     downloadManager = DownloadManager.new(retries = config.blockRetries)
-    advertiser = Advertiser.new(repoStore, discovery, peerInfo = switch.peerInfo)
+    advertiser = Advertiser.new(
+      repoStore,
+      discovery,
+      peerInfo = switch.peerInfo,
+      advertiseContent = config.advertiseContent,
+    )
     blockDiscovery = DiscoveryEngine.new(repoStore, peerStore, network, discovery)
     engine = BlockExcEngine.new(
       repoStore, network, blockDiscovery, advertiser, peerStore, downloadManager

--- a/tests/storage/blockexchange/engine/testadvertiser.nim
+++ b/tests/storage/blockexchange/engine/testadvertiser.nim
@@ -92,6 +92,19 @@ asyncchecksuite "Advertiser":
     check eventually manifestBlk.cid in advertised
     check manifest.treeCid notin advertised
 
+  test "Should not advertise when content advertising is disabled":
+    let newStore = CacheStore.new([manifestBlk])
+
+    await advertiser.stop()
+    advertiser = Advertiser.new(
+      newStore, blockDiscovery, peerInfo = examplePeerInfo(), advertiseContent = false
+    )
+    await advertiser.start()
+
+    (await newStore.putBlock(manifestBlk)).tryGet()
+
+    check always advertised.len == 0
+
   test "Stop should clear onBlockStored callback":
     await advertiser.stop()
 


### PR DESCRIPTION
### Downloading without announcing

A node that downloads a CID becomes a provider for it in the DHT. That is what spreads a package across the network. 

However, there are a lot of concerns regarding this usage in `logosctl` and the Basecamp app. While the first one contains a daemon that is supposed to be always running, the second one starts the Storage Module during the startup of the app, it doesn't seem long running enough to be a reliable provider. As soon as the CLI commands are done and the daemon is stopped or the app is closed, the node stops being a provider for the downloaded packages and the DHT will contain stale provider records which might seriously affect the network.

We need to introduce a new option for the Storage Module, which allows to opt in for announcing the downloaded packages to the DHT and becoming a provider for them. This option will be disabled by default for non storage nodes, and the user can enable it in the settings of the app or in `logosctl` if they want to contribute to the network.  

The node exposes it as `--advertise-content` (`advertiseContent` in the module JSON configuration), enabled by default so a storage node keeps announcing everything it holds. When it is disabled the node announces nothing: neither the packages it downloads nor the files it uploads. `logosctl` and the Basecamp app set it to `false` and offer a setting to turn it back on.

Note that this is particularly useful for anonymity over Mix, if someone wants to go for full privacy and not announce himself as provider. This has an impact on the network and decentralisation, we would prefer having more nodes participating in the network, but this seems a reasonable compromise for now.