### PR TITLE
feat: mix transport multiaddress

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -200,3 +200,6 @@
 [submodule "vendor/nim-libp2p-mix"]
 	path = vendor/nim-libp2p-mix
 	url = https://github.com/logos-co/nim-libp2p-mix
+[submodule "vendor/libp2p-mix-transport"]
+	path = vendor/libp2p-mix-transport
+	url = https://github.com/logos-storage/libp2p-mix-transport

--- a/config.nims
+++ b/config.nims
@@ -97,6 +97,8 @@ else:
 --define:
   "libp2p_multihash_exts:../../../storage/multihash_exts.nim"
 --define:
+  "libp2p_multiaddress_exts:../../../storage/multiaddress_exts.nim"
+--define:
   "libp2p_contentids_exts:../../../storage/contentids_exts.nim"
 
 when (NimMajor, NimMinor) >= (1, 4):

--- a/storage/multiaddress_exts.nim
+++ b/storage/multiaddress_exts.nim
@@ -1,0 +1,55 @@
+import std/base64
+
+import pkg/libp2p/crypto/[curve25519, secp]
+
+const MixTransportPayloadSize = Curve25519KeySize + SkRawPublicKeySize
+
+func validMixTransportPayload(payload: openArray[byte]): bool =
+  if payload.len != MixTransportPayloadSize:
+    return false
+
+  SkPublicKey.init(payload.toOpenArray(Curve25519KeySize, payload.high)).isOk
+
+proc mixTransportStB(s: string, vb: var VBuffer): bool =
+  let decoded =
+    try:
+      base64.decode(s)
+    except ValueError:
+      return false
+
+  if decoded.len != MixTransportPayloadSize or base64.encode(decoded, safe = true) != s:
+    return false
+
+  if not validMixTransportPayload(decoded.toOpenArrayByte(0, decoded.high)):
+    return false
+
+  vb.writeArray(decoded.toOpenArrayByte(0, decoded.high))
+  true
+
+proc mixTransportBtS(vb: var VBuffer, s: var string): bool =
+  var payload: array[MixTransportPayloadSize, byte]
+  if vb.readArray(payload) != MixTransportPayloadSize or
+      not validMixTransportPayload(payload):
+    return false
+
+  s = base64.encode(payload, safe = true)
+  true
+
+proc mixTransportVB(vb: var VBuffer): bool =
+  var payload: array[MixTransportPayloadSize, byte]
+  vb.readArray(payload) == MixTransportPayloadSize and validMixTransportPayload(payload)
+
+const
+  TranscoderMixTransport = Transcoder(
+    stringToBuffer: mixTransportStB,
+    bufferToString: mixTransportBtS,
+    validateBuffer: mixTransportVB,
+  )
+  AddressExts = [
+    MAProtocol(
+      mcodec: multiCodec("mix-transport"),
+      kind: Fixed,
+      size: MixTransportPayloadSize,
+      coder: TranscoderMixTransport,
+    )
+  ]

--- a/storage/multicodec_exts.nim
+++ b/storage/multicodec_exts.nim
@@ -1,2 +1,6 @@
-const CodecExts =
-  [("storage-manifest", 0xCD01), ("storage-block", 0xCD02), ("storage-root", 0xCD03)]
+const CodecExts = [
+  ("storage-manifest", 0xCD01),
+  ("storage-block", 0xCD02),
+  ("storage-root", 0xCD03),
+  ("mix-transport", 0xCD04),
+]

--- a/tests/storage/testmultiaddress_exts.nim
+++ b/tests/storage/testmultiaddress_exts.nim
@@ -1,0 +1,48 @@
+import std/base64
+
+import pkg/libp2p/[multicodec, multiaddress]
+import pkg/stew/byteutils
+import pkg/unittest2
+
+const
+  MixTransportPayloadHex =
+    "8a6571e8665fb1c894215f97d6a244591b655b1f5fd5ff7f928ef8b74aa66c5f" &
+    "03907bc5a41bec7c5ba11f8dfe6c7f779328d2d5bb48c9a978a11e09f3fbf61b3e"
+  EncodedMixTransportPayload =
+    "imVx6GZfsciUIV-X1qJEWRtlWx9f1f9_ko74t0qmbF8DkHvFpBvsfFuhH43-bH93" &
+    "kyjS1btIyal4oR4J8_v2Gz4="
+  MixTransportAddress =
+    "/ip4/127.0.0.1/tcp/8001/mix-transport/" & EncodedMixTransportPayload
+
+suite "mix-transport multiaddress extension":
+  test "encodes and decodes the address":
+    let address = MultiAddress.init(MixTransportAddress).expect("valid mix address")
+
+    check $address == MixTransportAddress
+
+    let payload = address.getProtocolArgument(multiCodec("mix-transport"))
+    check payload.isOk
+    check payload.get == hexToSeqByte(MixTransportPayloadHex)
+
+    let decoded = MultiAddress.init(address.data.buffer)
+    check decoded.isOk
+    check $decoded.get == MixTransportAddress
+
+  test "uses URL-safe base64 for the key payload":
+    let payload = hexToSeqByte(MixTransportPayloadHex)
+
+    check base64.encode(payload, safe = true) == EncodedMixTransportPayload
+    check '/' notin EncodedMixTransportPayload
+
+  test "rejects invalid base64":
+    check MultiAddress.init("/ip4/127.0.0.1/tcp/8001/mix-transport/not_base64!").isErr
+
+  test "rejects an incorrectly sized payload":
+    let encoded = base64.encode(newSeq[byte](64), safe = true)
+
+    check MultiAddress.init("/ip4/127.0.0.1/tcp/8001/mix-transport/" & encoded).isErr
+
+  test "rejects an invalid libp2p public key":
+    let encoded = base64.encode(newSeq[byte](65), safe = true)
+
+    check MultiAddress.init("/ip4/127.0.0.1/tcp/8001/mix-transport/" & encoded).isErr


### PR DESCRIPTION
This PR adds a mix-transport multiaddress which allows mix public information to be published as a provider record. This allows one to use an arbitrary provider as a mix exit node when performing downloads over mix.