### PR TITLE
feat: Mix transport addresses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -200,3 +200,6 @@
 [submodule "vendor/nim-libp2p-mix"]
 	path = vendor/nim-libp2p-mix
 	url = https://github.com/logos-co/nim-libp2p-mix
+[submodule "vendor/libp2p-mix-transport"]
+	path = vendor/libp2p-mix-transport
+	url = https://github.com/logos-storage/libp2p-mix-transport

--- a/config.nims
+++ b/config.nims
@@ -98,6 +98,8 @@ else:
   "libp2p_multihash_exts:../../../storage/multihash_exts.nim"
 --define:
   "libp2p_contentids_exts:../../../storage/contentids_exts.nim"
+--define:
+  "libp2p_multiaddress_exts:../../../storage/multiaddress_exts.nim"
 
 when (NimMajor, NimMinor) >= (1, 4):
   --warning:

--- a/storage/multiaddress_exts.nim
+++ b/storage/multiaddress_exts.nim
@@ -1,0 +1,5 @@
+includeFile "../vendor/libp2p-mix-transport/libp2p_mix_transport/address/ext.nim"
+
+const AddressExts = [
+  MixAddressExt
+]

--- a/storage/multiaddress_exts.nim
+++ b/storage/multiaddress_exts.nim
@@ -1,5 +1,3 @@
 includeFile "../vendor/libp2p-mix-transport/libp2p_mix_transport/address/ext.nim"
 
-const AddressExts = [
-  MixAddressExt
-]
+const AddressExts = [MixAddressExt]

--- a/storage/multicodec_exts.nim
+++ b/storage/multicodec_exts.nim
@@ -1,2 +1,6 @@
-const CodecExts =
-  [("storage-manifest", 0xCD01), ("storage-block", 0xCD02), ("storage-root", 0xCD03)]
+const CodecExts = [
+  ("storage-manifest", 0xCD01),
+  ("storage-block", 0xCD02),
+  ("storage-root", 0xCD03),
+  ("mix-transport", 0xCD04),
+]

--- a/storage/multicodec_exts.nim
+++ b/storage/multicodec_exts.nim
@@ -1,6 +1,9 @@
-const CodecExts = [
-  ("storage-manifest", 0xCD01),
-  ("storage-block", 0xCD02),
-  ("storage-root", 0xCD03),
-  ("mix-transport", 0xCD04),
-]
+# Keep the default registration's CodecExts local to this block so we can
+# combine it with Storage's codecs without duplicating MixTransport's value.
+const MixTransportCodecExts = block:
+  includeFile "../vendor/libp2p-mix-transport/libp2p_mix_transport/address/defaults/multicodec.nim"
+  CodecExts
+
+const CodecExts =
+  @[("storage-manifest", 0xCD01), ("storage-block", 0xCD02), ("storage-root", 0xCD03)] &
+  @MixTransportCodecExts

--- a/storage/rest/json.nim
+++ b/storage/rest/json.nim
@@ -128,7 +128,10 @@ proc init*(
 
   DebugInfo(
     id: peerId,
-    addrs: peerInfo.addrs,
+    # libp2p overrides the addresses announced in PeerInfo when announceAddrs are set. We
+    # reflect this here.
+    addrs:
+      if peerInfo.announcedAddrs.len == 0: peerInfo.addrs else: peerInfo.announcedAddrs,
     spr: node.discovery.getSpr().valueOr(""),
     table: RestRoutingTable.init(node.discovery),
     storage: VersionInfo(version: $storageVersion, revision: $storageRevision),

--- a/storage/rest/json.nim
+++ b/storage/rest/json.nim
@@ -128,10 +128,7 @@ proc init*(
 
   DebugInfo(
     id: peerId,
-    # libp2p overrides the addresses announced in PeerInfo when announceAddrs are set. We
-    # reflect this here.
-    addrs:
-      if peerInfo.announcedAddrs.len == 0: peerInfo.addrs else: peerInfo.announcedAddrs,
+    addrs: peerInfo.addrs,
     spr: node.discovery.getSpr().valueOr(""),
     table: RestRoutingTable.init(node.discovery),
     storage: VersionInfo(version: $storageVersion, revision: $storageRevision),

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -207,6 +207,8 @@ proc start*(self: StorageServer) {.async.} =
       error "Failed to derive mix address", err = mixAddress.error
     else:
       peerInfo.announcedAddrs.add(mixAddress.get)
+      # Refresh peerInfo to reflect the newly announced mix address.
+      await peerInfo.update()
 
   # Connect to the Autonat servers (currently bootsrap nodes) in order to
   # have connected peers for Autonat. The dials are run concurrently in case of

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -7,26 +7,28 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import std/os
-import std/tables
 import std/cpuinfo
 import std/net
+import std/os
 import std/sequtils
+import std/tables
 
 import pkg/chronos
-import pkg/taskpools
-import pkg/presto
+import pkg/confutils
+import pkg/confutils/defs
+import pkg/datastore
 import pkg/libp2p
 import pkg/libp2p/connmanager
+import pkg/libp2p/multiaddress
 import pkg/libp2p/protocols/connectivity/autonatv2/[service, client]
 import pkg/libp2p/protocols/connectivity/relay/client as relayClientModule
 import pkg/libp2p/protocols/connectivity/relay/relay as relayModule
 import pkg/libp2p/services/autorelayservice
 import pkg/libp2p/transports/tcptransport
 import pkg/libp2p_mix
-import pkg/confutils
-import pkg/confutils/defs
-import pkg/datastore
+import pkg/libp2p_mix_transport/address/parse
+import pkg/presto
+import pkg/taskpools
 
 import ./node
 import ./manifest/protocol
@@ -78,28 +80,72 @@ func node*(self: StorageServer): StorageNodeRef =
 func repoStore*(self: StorageServer): RepoStore =
   return self.repoStore
 
-proc start*(s: StorageServer) {.async.} =
-  if s.isStarted:
+proc enableMix(
+    self: StorageServer
+): Future[(MixProtocol, MixPool)] {.
+    async: (raises: [CancelledError, StorageError, LPError])
+.} =
+  let
+    switch = self.storageNode.switch
+    (mixPub, mixPriv) = loadOrGenerateMixKeys(
+      string(self.config.dataDir) / "mix-identity"
+    ).valueOr:
+      raise
+        newException(StorageError, "Failed to load or generate Mix keys: " & error.msg)
+    # We define a placeholder here.
+    # For nat:extip, the address will be updated by `updateLocalMultiAddr` on node start.
+    # For nat:auto, the node waits for AutoNAT to provide a reachable address or a relay address.
+    # The Mix lookup will not be performed while the mixAddr value is mixUnsetMultiAddr().
+    mixAddr = mixUnsetMultiAddr()
+    mixNodeInfo = buildMixNodeInfo(
+      mixPub, mixPriv, switch.peerInfo.peerId, mixAddr, switch.peerInfo.privateKey
+    ).valueOr:
+      raise newException(StorageError, "Failed to build Mix node info: " & error.msg)
+    relayPool = (
+      if self.config.mixPoolJson.len > 0:
+        loadRelayPubInfoTableFromJson(self.config.mixPoolJson)
+      else:
+        loadRelayPubInfoTableFromFile(self.config.mixPool)
+    ).valueOr:
+      raise newException(StorageError, "Failed to load Mix relay pool: " & error.msg)
+    mixProto = MixProtocol.new(mixNodeInfo, switch)
+
+  info "Starting node with Mix relay pool", count = relayPool.len
+
+  for info in relayPool.values:
+    mixProto.nodePool.add(info)
+
+  mixProto.registerDestReadBehavior(DhtProxyCodec, readLp(MaxLookupResponseBytes))
+  await mixProto.start()
+  switch.mount(mixProto)
+
+  # We don't care much WHERE in the address the mix component appears,
+  # as long as it's there.
+  switch.peerInfo.addressMappers.add(mixProto.addressMapper())
+  (mixProto, relayPool)
+
+proc start*(self: StorageServer) {.async.} =
+  if self.isStarted:
     warn "Storage server already started, skipping"
     return
 
-  trace "Starting Storage node", config = $s.config
-  await s.repoStore.start()
+  trace "Starting Storage node", config = $self.config
+  await self.repoStore.start()
 
-  s.maintenance.start()
+  self.maintenance.start()
 
   # Activate SO_REUSEPORT for hole punching in tcptransport.nim.
   # Without that, hole punching would use an ephemeral port assigned by the OS.
   # NotReachable has nothing to do with AutoNAT Reachability
-  if s.holePunchHandler.isSome:
-    for t in s.storageNode.switch.transports:
+  if self.holePunchHandler.isSome:
+    for t in self.storageNode.switch.transports:
       t.networkReachability = NetworkReachability.NotReachable
 
-  await s.storageNode.switch.start()
+  await self.storageNode.switch.start()
 
   var realPort = Port(0)
 
-  for listenAddr in s.storageNode.switch.peerInfo.listenAddrs:
+  for listenAddr in self.storageNode.switch.peerInfo.listenAddrs:
     let maybePort = getTcpPort(listenAddr)
     if maybePort.isSome:
       realPort = maybePort.get
@@ -108,79 +154,56 @@ proc start*(s: StorageServer) {.async.} =
   if realPort == Port(0):
     raise newException(StorageError, "Failed to determine the real TCP port")
 
-  if s.config.nat.hasExtIp:
+  let peerInfo = self.storageNode.switch.peerInfo
+  if self.config.nat.hasExtIp:
     # extip means that we assume the IP is reachable.
-    let extIpAddr = getMultiAddrWithIpAndTcpPort(s.config.nat.extIp, realPort)
-
+    let extIpAddr = getMultiAddrWithIpAndTcpPort(self.config.nat.extIp, realPort)
     # Feed switch.peerInfo.addrs with extIp value only.
     # For example, we want to make sure that relay servers will
     # contain only the extIp, no private addresses.
-    let peerInfo = s.storageNode.switch.peerInfo
     peerInfo.announcedAddrs = @[extIpAddr]
     # We force the update to take in consideration the announcedAddrs
     await peerInfo.update()
 
-  if s.config.mixEnabled:
+  if self.config.mixEnabled:
     let
-      switch = s.storageNode.switch
-      (mixPub, mixPriv) = loadOrGenerateMixKeys(
-        string(s.config.dataDir) / "mix-identity"
-      ).valueOr:
-        raise newException(
-          StorageError, "Failed to load or generate Mix keys: " & error.msg
-        )
-      # We define a placeholder here.
-      # For nat:extip, the address will be updated by `updateLocalMultiAddr` on node start.
-      # For nat:auto, the node waits for AutoNAT to provide a reachable address or a relay address.
-      # The Mix lookup will not be performed while the mixAddr value is mixUnsetMultiAddr().
-      mixAddr = mixUnsetMultiAddr()
-      mixNodeInfo = buildMixNodeInfo(
-        mixPub, mixPriv, switch.peerInfo.peerId, mixAddr, switch.peerInfo.privateKey
-      ).valueOr:
-        raise newException(StorageError, "Failed to build Mix node info: " & error.msg)
-      relayPool = (
-        if s.config.mixPoolJson.len > 0:
-          loadRelayPubInfoTableFromJson(s.config.mixPoolJson)
+      switch = self.storageNode.switch
+      (mixProto, relayPool) = await self.enableMix()
+
+      dhtProxyProto =
+        if cap =? self.config.dhtProxyMaxInFlight:
+          DhtProxyProtocol.new(self.storageNode.discovery, maxInFlight = cap)
         else:
-          loadRelayPubInfoTableFromFile(s.config.mixPool)
-      ).valueOr:
-        raise newException(StorageError, "Failed to load Mix relay pool: " & error.msg)
-      mixProto = MixProtocol.new(mixNodeInfo, switch)
+          DhtProxyProtocol.new(self.storageNode.discovery)
 
-    info "Starting node with Mix relay pool", count = relayPool.len
+    # Address mapping chains are skipped when we use extip, so we need to derive
+    # the mix address manually.
+    let mixAddress = mixProto.localMixPubInfo.toMixAddress()
+    if mixAddress.isErr:
+      error "Failed to derive mix address", err = mixAddress.error
+    else:
+      peerInfo.announcedAddrs.add(mixAddress.get)
 
-    for info in relayPool.values:
-      mixProto.nodePool.add(info)
-
-    mixProto.registerDestReadBehavior(DhtProxyCodec, readLp(MaxLookupResponseBytes))
-    await mixProto.start()
-    switch.mount(mixProto)
-
-    let dhtProxyProto =
-      if cap =? s.config.dhtProxyMaxInFlight:
-        DhtProxyProtocol.new(s.storageNode.discovery, maxInFlight = cap)
-      else:
-        DhtProxyProtocol.new(s.storageNode.discovery)
     await dhtProxyProto.start()
     switch.mount(dhtProxyProto)
 
-    s.storageNode.discovery.mixProto = mixProto
+    self.storageNode.discovery.mixProto = mixProto
 
-    if s.config.dhtMixProxies.len > 0:
-      discard s.storageNode.discovery.togglePrivateQueries(true).valueOr:
+    if self.config.dhtMixProxies.len > 0:
+      discard self.storageNode.discovery.togglePrivateQueries(true).valueOr:
         raise
           newException(StorageError, "Failed to enable private queries: " & error.msg)
 
-    s.storageNode.engine.network.excludeRelays(relayPool.keys.toSeq)
+    self.storageNode.engine.network.excludeRelays(relayPool.keys.toSeq)
 
-  if s.natMapper.isSome:
-    s.natMapper.get.start()
+  if self.natMapper.isSome:
+    self.natMapper.get.start()
 
   # When listenPort is 0 the OS assigns a random port.
-  if s.natMapper.isSome and s.config.listenPort == Port(0):
-    s.natMapper.get.tcpPort = realPort
+  if self.natMapper.isSome and self.config.listenPort == Port(0):
+    self.natMapper.get.tcpPort = realPort
 
-  await s.storageNode.start()
+  await self.storageNode.start()
 
   # Connect to the Autonat servers (currently bootsrap nodes) in order to
   # have connected peers for Autonat. The dials are run concurrently in case of
@@ -190,7 +213,7 @@ proc start*(s: StorageServer) {.async.} =
   ) {.async: (raises: [CancelledError]).} =
     try:
       let (peerId, addresses) = record.toPeerIdAndAddrs()
-      await s.storageNode.switch.connect(peerId, addresses)
+      await self.storageNode.switch.connect(peerId, addresses)
     except CancelledError as exc:
       raise exc
     except CatchableError as e:
@@ -199,18 +222,18 @@ proc start*(s: StorageServer) {.async.} =
   # noCancel: cancelling allFutures does not cancel the
   # connectAutonatServer futures.
   await noCancel allFutures(
-    findAutonatServers(s.bootstrapNodes).mapIt(connectAutonatServer(it))
+    findAutonatServers(self.bootstrapNodes).mapIt(connectAutonatServer(it))
   )
 
   # AutoNAT is not in switch.services because we want to start it
   # after the bootstrap connections to have connected peers for the first probe.
-  if s.autonatService.isSome:
-    await s.autonatService.get.start(s.storageNode.switch)
+  if self.autonatService.isSome:
+    await self.autonatService.get.start(self.storageNode.switch)
 
-  if s.restServer != nil:
-    s.restServer.start()
+  if self.restServer != nil:
+    self.restServer.start()
 
-  s.isStarted = true
+  self.isStarted = true
 
 proc stop*(s: StorageServer) {.async.} =
   if not s.isStarted:
@@ -385,7 +408,7 @@ proc new*(
     # Since Autonat V2 uses the observed public address,
     # we can filter the private addresses to keep only the dialable
     # addresses.
-    switchBuilder = switchBuilder.withAddressPolicy(dialableAddressPolicy)
+    switchBuilder = switchBuilder.withAddressPolicy(dialableMixAddressPolicy)
 
   let switch = switchBuilder
     .withTcpTransport({ServerFlags.ReuseAddr, ServerFlags.TcpNoDelay})

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -174,15 +174,6 @@ proc start*(self: StorageServer) {.async.} =
         else:
           DhtProxyProtocol.new(self.storageNode.discovery)
 
-    if self.config.nat.hasExtIp:
-      # Address mapping chains are skipped when we use extip, so
-      # we need to derive the mix address manually.
-      let mixAddress = mixProto.localMixPubInfo.toMixAddress()
-      if mixAddress.isErr:
-        error "Failed to derive mix address", err = mixAddress.error
-      else:
-        peerInfo.announcedAddrs.add(mixAddress.get)
-
     await dhtProxyProto.start()
     switch.mount(dhtProxyProto)
 
@@ -203,6 +194,19 @@ proc start*(self: StorageServer) {.async.} =
     self.natMapper.get.tcpPort = realPort
 
   await self.storageNode.start()
+
+  # Address mapping chains are skipped when we use extip, so
+  # we need to derive the mix address manually. We need to wait
+  # until AFTER storageNode.start as otherwise we'll see an
+  # uninitialized mix address.
+  if self.config.mixEnabled and self.config.nat.hasExtIp:
+    let
+      mixProto = self.storageNode.discovery.mixProto
+      mixAddress = mixProto.localMixPubInfo.toMixAddress()
+    if mixAddress.isErr:
+      error "Failed to derive mix address", err = mixAddress.error
+    else:
+      peerInfo.announcedAddrs.add(mixAddress.get)
 
   # Connect to the Autonat servers (currently bootsrap nodes) in order to
   # have connected peers for Autonat. The dials are run concurrently in case of

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -119,8 +119,6 @@ proc enableMix(
   await mixProto.start()
   switch.mount(mixProto)
 
-  # We don't care much WHERE in the address the mix component appears,
-  # as long as it's there.
   switch.peerInfo.addressMappers.add(mixProto.addressMapper())
   (mixProto, relayPool)
 
@@ -176,13 +174,14 @@ proc start*(self: StorageServer) {.async.} =
         else:
           DhtProxyProtocol.new(self.storageNode.discovery)
 
-    # Address mapping chains are skipped when we use extip, so we need to derive
-    # the mix address manually.
-    let mixAddress = mixProto.localMixPubInfo.toMixAddress()
-    if mixAddress.isErr:
-      error "Failed to derive mix address", err = mixAddress.error
-    else:
-      peerInfo.announcedAddrs.add(mixAddress.get)
+    if self.config.nat.hasExtIp:
+      # Address mapping chains are skipped when we use extip, so
+      # we need to derive the mix address manually.
+      let mixAddress = mixProto.localMixPubInfo.toMixAddress()
+      if mixAddress.isErr:
+        error "Failed to derive mix address", err = mixAddress.error
+      else:
+        peerInfo.announcedAddrs.add(mixAddress.get)
 
     await dhtProxyProto.start()
     switch.mount(dhtProxyProto)

--- a/storage/utils/mixidentity.nim
+++ b/storage/utils/mixidentity.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import std/[json, os, sequtils, tables]
+import std/[json, os, tables]
 
 import pkg/chronicles
 import pkg/libp2p
@@ -56,20 +56,16 @@ proc pickMixCompatibleMultiAddr*(addrs: openArray[MultiAddress]): Opt[MultiAddre
 
 proc addressMapper*(proto: MixProtocol): AddressMapper =
   proc(
-      currentAddrs: seq[MultiAddress]
+      listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
-    result = currentAddrs
-    let endpoint = pickMixCompatibleMultiAddr(
-      currentAddrs.filterIt(dialableAddressPolicy(it))
-    ).valueOr:
-      return
-
-    # The address-change observer updates Mix only after this mapper returns.
-    # Build the advertisement from the current mapper input, not Mix's previous
-    # endpoint. The observer remains responsible for updating Mix's own state.
-    var info = proto.localMixPubInfo
-    info.multiAddr = endpoint
-    let mixAddress = info.toMixAddress().valueOr:
+    result = listenAddrs
+    # AutoNAT and AutoRelay may register mappers after this one, so this input
+    # need not contain the final reachable endpoint. Use the endpoint saved by
+    # the observer after the previous address update. This can remain stale
+    # until another update occurs.
+    # TODO: derive the Mix advertisement after all endpoint-producing mappers,
+    # with a regression test covering a later mapper supplying the endpoint.
+    let mixAddress = proto.localMixPubInfo.toMixAddress().valueOr:
       error "Failed to get Mix address", err = error
       return
 

--- a/storage/utils/mixidentity.nim
+++ b/storage/utils/mixidentity.nim
@@ -58,12 +58,14 @@ proc addressMapper*(proto: MixProtocol): AddressMapper =
   proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
+    result = listenAddrs
     # The address in nodeInfo should always be up-to-date, so we
     # just take that one.
     let mixAddress = proto.localMixPubInfo.toMixAddress().valueOr:
       error "Failed to get Mix address", err = error
       return
 
+    trace "derived new mix transport address", address = mixAddress
     result.add(mixAddress)
 
 proc dialableMixAddressPolicy*(ma: MultiAddress): bool {.gcsafe, raises: [].} =

--- a/storage/utils/mixidentity.nim
+++ b/storage/utils/mixidentity.nim
@@ -11,21 +11,29 @@
 
 import std/[json, os, tables]
 
+import pkg/chronicles
 import pkg/libp2p
 import pkg/libp2p/wire
 import pkg/libp2p/crypto/crypto
 import pkg/libp2p/crypto/secp
 import pkg/libp2p_mix
 import pkg/libp2p_mix/[curve25519, mix_node]
+import pkg/libp2p_mix_transport/address/parse
 import pkg/libp2p/crypto/curve25519 as libp2p_curve25519
 import pkg/questionable/results
 import pkg/stew/byteutils
 
 import ../errors
+import ./addrutils
+
+logScope:
+  topics = "storage mixidentity"
 
 const PoolFormatVersion = 1
 
 const MixIdentityFileSize = 2 * FieldElementSize
+
+type MixPool* = Table[PeerId, MixPubInfo]
 
 proc mixUnsetMultiAddr*(): MultiAddress =
   ## Placeholder multiaddr for a mix node that has not yet been assigned a real multiaddr.
@@ -45,6 +53,32 @@ proc pickMixCompatibleMultiAddr*(addrs: openArray[MultiAddress]): Opt[MultiAddre
       return Opt.some(ma)
 
   Opt.none(MultiAddress)
+
+proc addressMapper*(proto: MixProtocol): AddressMapper =
+  proc(
+      listenAddrs: seq[MultiAddress]
+  ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
+    # The address in nodeInfo should always be up-to-date, so we
+    # just take that one.
+    let mixAddress = proto.localMixPubInfo.toMixAddress().valueOr:
+      error "Failed to get Mix address", err = error
+      return
+
+    result.add(mixAddress)
+
+proc dialableMixAddressPolicy*(ma: MultiAddress): bool {.gcsafe, raises: [].} =
+  ## Replacement policy for `dialableAddressPolicy` which allows an address if either:
+  ##  1. the address itself is dialable;
+  ##  2. the address is a valid mix transport address, and its underlying multiaddr is
+  ##     dialable.
+  if dialableAddressPolicy(ma):
+    return true
+
+  let pubMixInfo = MixPubInfo.fromMixAddress(ma, Opt.none(PeerId)).valueOr:
+    # not a valid mix address
+    return false
+
+  return dialableAddressPolicy(pubMixInfo.multiAddr)
 
 proc loadOrGenerateMixKeys*(
     path: string
@@ -172,7 +206,7 @@ proc pubInfoFromJson(node: JsonNode): ?!MixPubInfo =
 
   success MixPubInfo.init(peerId, multiAddr, mixPubKey, libp2pPubKey)
 
-proc loadRelayPubInfoTableFromJson*(poolJson: string): ?!Table[PeerId, MixPubInfo] =
+proc loadRelayPubInfoTableFromJson*(poolJson: string): ?!MixPool =
   ## Expected format:
   ##   { "version": 1, "relays": [ { peerId, multiAddr, mixPubKey, libp2pPubKey }, ... ] }
   if poolJson.len == 0:
@@ -199,7 +233,7 @@ proc loadRelayPubInfoTableFromJson*(poolJson: string): ?!Table[PeerId, MixPubInf
 
   success t
 
-proc loadRelayPubInfoTableFromFile*(poolPath: string): ?!Table[PeerId, MixPubInfo] =
+proc loadRelayPubInfoTableFromFile*(poolPath: string): ?!MixPool =
   if poolPath.len == 0:
     return success initTable[PeerId, MixPubInfo]()
 

--- a/storage/utils/mixidentity.nim
+++ b/storage/utils/mixidentity.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import std/[json, os, tables]
+import std/[json, os, sequtils, tables]
 
 import pkg/chronicles
 import pkg/libp2p
@@ -56,12 +56,20 @@ proc pickMixCompatibleMultiAddr*(addrs: openArray[MultiAddress]): Opt[MultiAddre
 
 proc addressMapper*(proto: MixProtocol): AddressMapper =
   proc(
-      listenAddrs: seq[MultiAddress]
+      currentAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
-    result = listenAddrs
-    # The address in nodeInfo should always be up-to-date, so we
-    # just take that one.
-    let mixAddress = proto.localMixPubInfo.toMixAddress().valueOr:
+    result = currentAddrs
+    let endpoint = pickMixCompatibleMultiAddr(
+      currentAddrs.filterIt(dialableAddressPolicy(it))
+    ).valueOr:
+      return
+
+    # The address-change observer updates Mix only after this mapper returns.
+    # Build the advertisement from the current mapper input, not Mix's previous
+    # endpoint. The observer remains responsible for updating Mix's own state.
+    var info = proto.localMixPubInfo
+    info.multiAddr = endpoint
+    let mixAddress = info.toMixAddress().valueOr:
       error "Failed to get Mix address", err = error
       return
 

--- a/tests/integration/1_minute/testmix.nim
+++ b/tests/integration/1_minute/testmix.nim
@@ -1,10 +1,25 @@
 import std/json
+import std/sequtils
 
+import pkg/libp2p/[multiaddress, peerid]
+import pkg/libp2p_mix
+import pkg/libp2p_mix_transport/address/parse
 import pkg/questionable/results
+import pkg/results
 
 import ../multinodes
+import ../nat/composehelper
 
 multinodesuite "Mix startup":
+  test "should publish a mix address when Mix is enabled and nat:extip is set",
+    NodeConfigs(
+      clients:
+        StorageConfigs.init(nodes = 2).withExtIp(1, "127.0.0.1").withMixEnabled().some
+    ):
+    check eventuallyInfo(
+      clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
+    )
+
   test "a nat:auto node starts with Mix enabled",
     NodeConfigs(clients: StorageConfigs.init(nodes = 2).withMixEnabled().some):
     let info = (await clients()[1].client.info()).get

--- a/tests/integration/1_minute/testmix.nim
+++ b/tests/integration/1_minute/testmix.nim
@@ -14,12 +14,29 @@ multinodesuite "Mix startup":
   # We can only test the extip path here as non-extip requires public addresses.
   test "should publish a mix address when Mix is enabled and nat:extip is set",
     NodeConfigs(
-      clients:
-        StorageConfigs.init(nodes = 2).withExtIp(1, "127.0.0.1").withMixEnabled().some
+      clients: StorageConfigs
+        .init(nodes = 2)
+        .withExtIp(1, "127.0.0.1")
+        .withListenPort(1, 40401)
+        .withMixEnabled().some
     ):
     check eventuallyInfo(
       clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
     )
+
+    let
+      info = (await clients()[1].client.info()).get
+      mixAddresses = info{"addrs"}.getElems.filterIt("mix-transport" in it.getStr)
+
+    check mixAddresses.len == 1
+
+    let
+      mixAddress = mixAddresses[0].getStr
+      mixInfo = MixPubInfo.fromMixAddress(
+        MultiAddress.init(mixAddress).get, Opt.none(PeerId)
+      ).get
+
+    check mixInfo.multiAddr == MultiAddress.init("/ip4/127.0.0.1/tcp/40401").get
 
   test "a nat:auto node starts with Mix enabled",
     NodeConfigs(clients: StorageConfigs.init(nodes = 2).withMixEnabled().some):

--- a/tests/integration/1_minute/testmix.nim
+++ b/tests/integration/1_minute/testmix.nim
@@ -11,18 +11,12 @@ import ../multinodes
 import ../nat/composehelper
 
 multinodesuite "Mix startup":
-  # Paths for extip and non-extip are different, so we put tests for both in place.
+  # We can only test the extip path here as non-extip requires public addresses.
   test "should publish a mix address when Mix is enabled and nat:extip is set",
     NodeConfigs(
       clients:
         StorageConfigs.init(nodes = 2).withExtIp(1, "127.0.0.1").withMixEnabled().some
     ):
-    check eventuallyInfo(
-      clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
-    )
-
-  test "should publish a mix address when Mix is enabled",
-    NodeConfigs(clients: StorageConfigs.init(nodes = 2).withMixEnabled().some):
     check eventuallyInfo(
       clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
     )

--- a/tests/integration/1_minute/testmix.nim
+++ b/tests/integration/1_minute/testmix.nim
@@ -11,11 +11,18 @@ import ../multinodes
 import ../nat/composehelper
 
 multinodesuite "Mix startup":
+  # Paths for extip and non-extip are different, so we put tests for both in place.
   test "should publish a mix address when Mix is enabled and nat:extip is set",
     NodeConfigs(
       clients:
         StorageConfigs.init(nodes = 2).withExtIp(1, "127.0.0.1").withMixEnabled().some
     ):
+    check eventuallyInfo(
+      clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
+    )
+
+  test "should publish a mix address when Mix is enabled",
+    NodeConfigs(clients: StorageConfigs.init(nodes = 2).withMixEnabled().some):
     check eventuallyInfo(
       clients()[1].client, info{"addrs"}.getElems.anyIt("mix-transport" in it.getStr)
     )

--- a/tests/storage/utils/testmixidentity.nim
+++ b/tests/storage/utils/testmixidentity.nim
@@ -1,8 +1,13 @@
 import std/tables
 
+import pkg/chronos
 import pkg/unittest2
+import pkg/libp2p/builders
+import pkg/libp2p/crypto/crypto
 import pkg/libp2p/peerid
 import pkg/libp2p/multiaddress
+import pkg/libp2p_mix
+import pkg/libp2p_mix_transport/address/parse
 import pkg/storage/utils/mixidentity {.all.}
 
 const SamplePoolJson = """
@@ -24,6 +29,55 @@ const SamplePoolJson = """
   ]
 }
 """
+
+suite "mixidentity / addressMapper":
+  setup:
+    let
+      rng = newRng()
+      switch = SwitchBuilder
+        .new()
+        .withRng(rng)
+        .withTcpTransport()
+        .withMplex()
+        .withNoise()
+        .build()
+      mix = MixProtocol.new(MixNodeInfo.generateRandom(8080, rng), switch)
+      mapper = mix.addressMapper()
+      current = MultiAddress.init("/ip4/8.8.8.8/tcp/8081").expect("current endpoint")
+
+  test "uses current addresses before the observer updates Mix":
+    # Mix still holds its old endpoint when libp2p calls the mapper. No network
+    # is needed: supplying a new endpoint reproduces the address-update order.
+    let previous = mix.localMixPubInfo.multiAddr
+    let mapped = waitFor mapper(@[current])
+    check mapped.len == 2
+    check mapped[0] == current
+    let decoded = MixPubInfo
+      .fromMixAddress(mapped[1], Opt.some(mix.localMixPubInfo.peerId))
+      .expect("advertised Mix address")
+    check decoded.multiAddr == current
+    # The mapper constructs an advertisement; it does not update Mix's state.
+    check mix.localMixPubInfo.multiAddr == previous
+
+  test "does not advertise a cached endpoint when no eligible address remains":
+    mix.setLocalMultiAddr(current).expect("set previous endpoint")
+    let unavailable = @[
+      mixUnsetMultiAddr(),
+      MultiAddress.init("/ip4/192.168.1.2/tcp/8081").expect("private endpoint"),
+      MultiAddress.init("/ip4/8.8.8.8/udp/8081").expect("unsupported endpoint"),
+    ]
+    check (waitFor mapper(unavailable)) == unavailable
+    check (waitFor mapper(@[])).len == 0
+
+  test "skips private endpoints before selecting a public endpoint":
+    let
+      privateAddr = MultiAddress.init("/ip4/192.168.1.2/tcp/8081").expect("private")
+      mapped = waitFor mapper(@[privateAddr, current])
+      decoded = MixPubInfo
+        .fromMixAddress(mapped[^1], Opt.some(mix.localMixPubInfo.peerId))
+        .expect("advertised Mix address")
+    check mapped.len == 3
+    check decoded.multiAddr == current
 
 suite "mixidentity / loadRelayPubInfoTableFromJson":
   test "empty string yields an empty table":

--- a/tests/storage/utils/testmixidentity.nim
+++ b/tests/storage/utils/testmixidentity.nim
@@ -1,13 +1,8 @@
 import std/tables
 
-import pkg/chronos
 import pkg/unittest2
-import pkg/libp2p/builders
-import pkg/libp2p/crypto/crypto
 import pkg/libp2p/peerid
 import pkg/libp2p/multiaddress
-import pkg/libp2p_mix
-import pkg/libp2p_mix_transport/address/parse
 import pkg/storage/utils/mixidentity {.all.}
 
 const SamplePoolJson = """
@@ -29,55 +24,6 @@ const SamplePoolJson = """
   ]
 }
 """
-
-suite "mixidentity / addressMapper":
-  setup:
-    let
-      rng = newRng()
-      switch = SwitchBuilder
-        .new()
-        .withRng(rng)
-        .withTcpTransport()
-        .withMplex()
-        .withNoise()
-        .build()
-      mix = MixProtocol.new(MixNodeInfo.generateRandom(8080, rng), switch)
-      mapper = mix.addressMapper()
-      current = MultiAddress.init("/ip4/8.8.8.8/tcp/8081").expect("current endpoint")
-
-  test "uses current addresses before the observer updates Mix":
-    # Mix still holds its old endpoint when libp2p calls the mapper. No network
-    # is needed: supplying a new endpoint reproduces the address-update order.
-    let previous = mix.localMixPubInfo.multiAddr
-    let mapped = waitFor mapper(@[current])
-    check mapped.len == 2
-    check mapped[0] == current
-    let decoded = MixPubInfo
-      .fromMixAddress(mapped[1], Opt.some(mix.localMixPubInfo.peerId))
-      .expect("advertised Mix address")
-    check decoded.multiAddr == current
-    # The mapper constructs an advertisement; it does not update Mix's state.
-    check mix.localMixPubInfo.multiAddr == previous
-
-  test "does not advertise a cached endpoint when no eligible address remains":
-    mix.setLocalMultiAddr(current).expect("set previous endpoint")
-    let unavailable = @[
-      mixUnsetMultiAddr(),
-      MultiAddress.init("/ip4/192.168.1.2/tcp/8081").expect("private endpoint"),
-      MultiAddress.init("/ip4/8.8.8.8/udp/8081").expect("unsupported endpoint"),
-    ]
-    check (waitFor mapper(unavailable)) == unavailable
-    check (waitFor mapper(@[])).len == 0
-
-  test "skips private endpoints before selecting a public endpoint":
-    let
-      privateAddr = MultiAddress.init("/ip4/192.168.1.2/tcp/8081").expect("private")
-      mapped = waitFor mapper(@[privateAddr, current])
-      decoded = MixPubInfo
-        .fromMixAddress(mapped[^1], Opt.some(mix.localMixPubInfo.peerId))
-        .expect("advertised Mix address")
-    check mapped.len == 3
-    check decoded.multiAddr == current
 
 suite "mixidentity / loadRelayPubInfoTableFromJson":
   test "empty string yields an empty table":


### PR DESCRIPTION
This PR adds Mix transport address advertisement when Mix is enabled in a storage node. This is the first step in getting anonymous downloads working as it allows providers to advertise enough information to be reachable over Mix for the files they advertise.