### PR TITLE
chore: update Nim to 2.2.12

### DIFF
--- a/.github/workflows/bootstrap-health-check.yml
+++ b/.github/workflows/bootstrap-health-check.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  nim_version: v2.2.10
+  nim_version: v2.2.12
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v2.2.10
+  nim_version: v2.2.12
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ make coverage && make show-coverage
 
 ## Key Development Notes
 
-- **Nim version**: pinned to `v2.2.10` (see `Makefile`). Override with `NIM_COMMIT=<version>`.
-- **Memory model**: ORC (`--mm:orc`) for Nim ≥ 2.0, refc for the C library build.
+- **Nim version**: pinned to `v2.2.12` (see `Makefile`). Override with `NIM_COMMIT=<version>`.
+- **Memory model**: ORC (`--mm:refc`) for Nim ≥ 2.0, refc for the C library build.
 - **Error handling**: uses `questionable/results` (`?!T`, `?T`) throughout — avoid bare exceptions. The codebase enforces `{.push raises: [].}` broadly.
 - **Logging**: uses `chronicles` with runtime filtering. Topics are set per-module via `logScope`. Build with `-d:chronicles_log_level=TRACE` to enable all log levels.
 - **Style**: `--styleCheck:error` is enabled — identifiers must match declaration casing exactly.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 # If NIM_COMMIT is set to "nimbusbuild", this will use the
 # version pinned by nimbus-build-system.
-PINNED_NIM_VERSION := v2.2.10
+PINNED_NIM_VERSION := v2.2.12
 
 ifeq ($(NIM_COMMIT),)
 NIM_COMMIT := $(PINNED_NIM_VERSION)

--- a/config.nims
+++ b/config.nims
@@ -116,6 +116,10 @@ when (NimMajor, NimMinor) >= (2, 0):
   --mm:
     refc
 
+# Nim 2.2.12 rejects the merkletree compress closure.
+when (NimMajor, NimMinor, NimPatch) >= (2, 2, 12):
+  switch("legacy", "procParamTypeBackendAliases")
+
 switch("define", "withoutPCRE")
 
 # the default open files limit is too low on macOS (512), breaking the

--- a/storage/storage.nim
+++ b/storage/storage.nim
@@ -515,7 +515,7 @@ proc new*(
       )
     )
 
-    autonatService.get.setStatusAndConfidenceHandler(
+    discard autonatService.get.reachabilityObservers.add(
       proc(
           networkReachability: NetworkReachability,
           confidence: Opt[float],

--- a/tests/integration/nat/Dockerfile
+++ b/tests/integration/nat/Dockerfile
@@ -4,7 +4,7 @@
 # Build context = project root.
 FROM ubuntu:24.04
 
-ARG NIM_VERSION=2.2.10
+ARG NIM_VERSION=2.2.12
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ make cmake git curl ca-certificates xz-utils \


### PR DESCRIPTION
This PR updates Nim to 2.2.12. 

It adds `procParamTypeBackendAliases` for `merkletree` compatibility and corrects the memory management definition in Claude file. 

Additionally it calls `reachabilityObservers` instead of `setStatusAndConfidenceHandler` to remove a deprecation notice.